### PR TITLE
[WIP] feat: use sqlite as lock for snap management

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -22,7 +22,7 @@ from snap_lock import SnapLock
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
-VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
+VALID_LOG_LEVELS = ['info', 'debug', 'warning', 'error', 'critical']
 
 SNAPS = [opentelemetry_collector_snap_name, node_exporter_snap_name]
 
@@ -40,28 +40,27 @@ class OpentelemetryCollectorOperatorCharm(ops.CharmBase):
         self.unit.status = ActiveStatus()
 
     def _install(self) -> None:
-        if self.hook != "install":
+        if self.hook != 'install':
             return
 
         lock = SnapLock(self.unit.name)
         for snap_package in SNAPS:
-            with lock.lock_snap(snap_package) as acquired:
-                if acquired:
-                    lock.register(snap_package)
+            with lock.lock_snap(snap_package):
+                lock.register(snap_package)
 
-                    self._install_snap(snap_package)
-                    self._start_snap(snap_package)
+                self._install_snap(snap_package)
+                self._start_snap(snap_package)
 
-                    logger.debug(
-                        f"======= Unit name: {self.unit.name}, snap: {snap_package} registered"
-                    )
-                    # debug
-                    logger.debug(
-                        f"======= Unit name: {self.unit.name}, snap: {snap_package} used by: {lock.used_by(snap_package)}",
-                    )
+                logger.debug(
+                    f'======= Unit name: {self.unit.name}, snap: {snap_package} registered'
+                )
+                # debug
+                logger.debug(
+                    f'======= Unit name: {self.unit.name}, snap: {snap_package} used by: {lock.used_by(snap_package)}',
+                )
 
     def _remove(self) -> None:
-        if self.hook != "remove":
+        if self.hook != 'remove':
             return
 
         lock = SnapLock(self.unit.name)
@@ -69,38 +68,37 @@ class OpentelemetryCollectorOperatorCharm(ops.CharmBase):
             lock.unregister(snap_package)
             # debug
             logger.debug(
-                f"======= Unit name: {self.unit.name}, snap: {snap_package} used by: {lock.used_by(snap_package)}",
+                f'======= Unit name: {self.unit.name}, snap: {snap_package} used by: {lock.used_by(snap_package)}',
             )
 
             if not lock.used_by_others(snap_package):
                 logger.debug(
-                    f"======= Unit name: {self.unit.name}, snap: {snap_package} not used by others"
+                    f'======= Unit name: {self.unit.name}, snap: {snap_package} not used by others'
                 )
-                with lock.lock_snap(snap_package) as acquired:
-                    if acquired:
-                        self._remove_snap(snap_package)
+                with lock.lock_snap(snap_package):
+                    self._remove_snap(snap_package)
 
     def _install_snap(self, snap_name: str) -> None:
-        self.unit.status = MaintenanceStatus(f"Installing {snap_name} snap")
+        self.unit.status = MaintenanceStatus(f'Installing {snap_name} snap')
         try:
             install_snap(snap_name)
         except (snap.SnapError, SnapSpecError) as e:
-            raise SnapInstallError(f"Failed to install {snap_name}") from e
+            raise SnapInstallError(f'Failed to install {snap_name}') from e
 
     def _remove_snap(self, snap_name: str) -> None:
-        self.unit.status = MaintenanceStatus(f"Uninstalling {snap_name} snap")
+        self.unit.status = MaintenanceStatus(f'Uninstalling {snap_name} snap')
         try:
             self.snap(snap_name).ensure(state=snap.SnapState.Absent)
         except (snap.SnapError, SnapSpecError) as e:
-            raise SnapInstallError(f"Failed to uninstall {snap_name}") from e
+            raise SnapInstallError(f'Failed to uninstall {snap_name}') from e
 
     def _start_snap(self, snap_name: str) -> None:
-        self.unit.status = MaintenanceStatus(f"Starting {snap_name} snap")
+        self.unit.status = MaintenanceStatus(f'Starting {snap_name} snap')
 
         try:
             self.snap(snap_name).start(enable=True)
         except snap.SnapError as e:
-            raise SnapServiceError(f"Failed to start {snap_name}") from e
+            raise SnapServiceError(f'Failed to start {snap_name}') from e
 
     def snap(self, snap_name: str):
         """Return the snap object for the given snap."""
@@ -110,8 +108,8 @@ class OpentelemetryCollectorOperatorCharm(ops.CharmBase):
     @property
     def hook(self) -> str:
         """Return hook name."""
-        return os.environ["JUJU_HOOK_NAME"]
+        return os.environ['JUJU_HOOK_NAME']
 
 
-if __name__ == "__main__":  # pragma: nocover
+if __name__ == '__main__':  # pragma: nocover
     ops.main(OpentelemetryCollectorOperatorCharm)

--- a/src/snap_lock.py
+++ b/src/snap_lock.py
@@ -1,0 +1,303 @@
+"""Snap Lock Module."""
+
+import sqlite3
+import time
+from contextlib import contextmanager
+from typing import Generator
+
+
+class SnapLock:
+    """SnapLock provides mechanisms for singleton snaps."""
+
+    def __init__(self, instance_id: str, lock_timeout_sec: int = 300):
+        self.instance_id = instance_id
+        self.db_path = "/tmp/snap_lock.db"
+        self.lock_timeout = lock_timeout_sec
+
+        self._init_db()
+
+    def _init_db(self):
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS active_instances (
+                    instance_id TEXT,
+                    snap_name TEXT,
+                    PRIMARY KEY (instance_id, snap_name)
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS snap_locks (
+                    snap_name TEXT PRIMARY KEY,
+                    locked_by TEXT,
+                    lock_time TIMESTAMP
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS config_locks (
+                    config_path TEXT PRIMARY KEY,
+                    locked_by TEXT,
+                    lock_time TIMESTAMP
+                )
+            """)
+            conn.commit()
+
+    def register(self, snap_name: str):
+        """Registers an instance using this snap."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = conn.cursor()
+
+                # Record this instance
+                cursor.execute(
+                    "INSERT INTO active_instances VALUES (?, ?)",
+                    (
+                        self.instance_id,
+                        snap_name,
+                    ),
+                )
+
+                conn.commit()
+            except Exception as e:
+                print(f"Error during registration: {e}")
+                conn.rollback()
+                raise
+
+    def unregister(self, snap_name: str):
+        """Unregisters an instance using the snap."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = conn.cursor()
+
+                # Remove instance record
+                cursor.execute(
+                    "DELETE FROM active_instances WHERE instance_id = ? AND snap_name = ?",
+                    (self.instance_id, snap_name),
+                )
+
+                conn.commit()
+            except Exception as e:
+                print(f"Error during unregistration: {e}")
+                conn.rollback()
+                raise
+
+    def used_by(self, snap_name: str) -> list[str]:
+        """Returns a list of instance IDs that are currently using the specified snap."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT instance_id FROM active_instances WHERE snap_name = ?
+                """,
+                (snap_name,),
+            )
+            instances = [row[0] for row in cursor.fetchall()]
+            return instances
+
+    def used_by_others(self, snap_name: str) -> bool:
+        """Returns True if the snap is used by other instances besides the current instance, False otherwise."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT instance_id FROM active_instances WHERE snap_name = ? AND instance_id != ?
+                """,
+                (snap_name, self.instance_id),
+            )
+            return cursor.fetchone() is not None
+
+    @contextmanager
+    def lock_snap(self, snap_name: str, timeout: int = 3) -> Generator[bool, None, None]:
+        """Context manager to acquire a lock on a snap for exclusive access.
+
+        Example usage:
+        with lock.lock_snap('otelcol') as acquired:
+            if acquired:
+                # Perform operations on the snap
+            else:
+                # Handle the case where the snap lock was not acquired
+        """
+        acquired = self._acquire_snap_lock(snap_name, timeout)
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                self._release_snap_lock(snap_name)
+
+    def _acquire_snap_lock(self, snap_name: str, timeout: int) -> bool:
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            with sqlite3.connect(self.db_path) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    cursor = conn.cursor()
+                    # Check for existing lock
+                    cursor.execute(
+                        """
+                        SELECT locked_by, lock_time FROM snap_locks 
+                        WHERE snap_name = ?
+                        """,
+                        (snap_name,),
+                    )
+
+                    if result := cursor.fetchone():
+                        locked_by, lock_time = result
+                        # Check if lock is stale
+                        cursor.execute(
+                            """
+                            SELECT (strftime('%s','now') - strftime('%s',?)) > ?
+                            """,
+                            (lock_time, self.lock_timeout),
+                        )
+
+                        if cursor.fetchone()[0]:  # Stale lock
+                            conn.execute(
+                                """
+                                DELETE FROM snap_locks 
+                                WHERE snap_name = ?
+                                """,
+                                (snap_name,),
+                            )
+                            conn.commit()
+                            continue
+
+                        if locked_by == self.instance_id:  # We already hold it
+                            return True
+
+                        # Active lock held by others
+                        time.sleep(1)
+                        continue
+
+                    # Acquire new lock
+                    conn.execute(
+                        """
+                        INSERT INTO snap_locks 
+                        VALUES (?, ?, datetime('now'))
+                        """,
+                        (snap_name, self.instance_id),
+                    )
+                    conn.commit()
+                    return True
+
+                except sqlite3.IntegrityError:  # Race condition
+                    time.sleep(1)
+                    continue
+
+        return False
+
+    def _release_snap_lock(self, snap_name) -> bool:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    DELETE FROM snap_locks 
+                    WHERE snap_name = ? AND locked_by = ?
+                    """,
+                    (snap_name, self.instance_id),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+            except Exception:
+                conn.rollback()
+                return False
+
+    @contextmanager
+    def lock_config(self, config_path: str, timeout: int = 3) -> Generator[bool, None, None]:
+        """Context manager to acquire a lock on a config file for exclusive access.
+
+        Example usage:
+        with lock.lock_config('/etc/otelcol/config.yaml') as acquired:
+            if acquired:
+                # Perform operations on the config
+            else:
+                # Handle the case where the config lock was not acquired
+        """
+        acquired = self._acquire_config_lock(config_path, timeout)
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                self._release_config_lock(config_path)
+
+    def _acquire_config_lock(self, config_path: str, timeout: int) -> bool:
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            with sqlite3.connect(self.db_path) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    cursor = conn.cursor()
+                    # Check for existing lock
+                    cursor.execute(
+                        """
+                        SELECT locked_by, lock_time FROM config_locks
+                        WHERE config_path = ?
+                        """,
+                        (config_path,),
+                    )
+
+                    if result := cursor.fetchone():
+                        locked_by, lock_time = result
+                        # Check if lock is stale
+                        cursor.execute(
+                            """
+                            SELECT (strftime('%s','now') - strftime('%s',?)) > ?
+                            """,
+                            (lock_time, self.lock_timeout),
+                        )
+
+                        if cursor.fetchone()[0]:  # Stale lock
+                            conn.execute(
+                                """
+                                DELETE FROM config_locks
+                                WHERE config_path = ?
+                                """,
+                                (config_path,),
+                            )
+                            conn.commit()
+                            continue
+
+                        if locked_by == self.instance_id:  # We already hold it
+                            return True
+
+                        # Active lock held by others
+                        time.sleep(1)
+                        continue
+
+                    # Acquire new lock
+                    conn.execute(
+                        """
+                        INSERT INTO config_locks
+                        VALUES (?, ?, datetime('now'))
+                        """,
+                        (config_path, self.instance_id),
+                    )
+                    conn.commit()
+                    return True
+
+                except sqlite3.IntegrityError:  # Race condition
+                    time.sleep(1)
+                    continue
+
+        return False
+
+    def _release_config_lock(self, config_path) -> bool:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    DELETE FROM config_locks
+                    WHERE config_path = ? AND locked_by = ?
+                    """,
+                    (config_path, self.instance_id),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+            except Exception:
+                conn.rollback()
+                return False


### PR DESCRIPTION
Proof of concept, _do not merge_.

This PR uses SQLite as a lock and reference counter when handling snaps. Each unit "registers" itself with a snap when installing and "unregisters" itself from that snap when uninstalling. The snap would only be removed if there are no other units registered with the snap.

See manual tests below.

Todo:

- Handle corner cases with defensive programming. For example, when a unit is already registered with the snap.
- Design the class/interface, maybe merge it with `snap` within `operator-libs-linux`, or make it a standalone class.
- Merge configs.