### PR TITLE
feat: remove locking mechanism and refactor unclear patterns

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-# Copyright 2025 jose
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-# Learn more at: https://juju.is/docs/sdk
 """A Juju charm for OpenTelemetry Collector on machines."""
 
 import logging
@@ -14,11 +12,8 @@ from snap_management import (
     SnapSpecError,
     SnapInstallError,
     SnapServiceError,
-    get_system_arch,
     install_snap,
-    node_exporter_snap_name,
-    opentelemetry_collector_snap_name,
-    snap_maps,
+    SnapMap,
 )
 from singleton_snap import SingletonSnapManager
 
@@ -26,7 +21,10 @@ from singleton_snap import SingletonSnapManager
 logger = logging.getLogger(__name__)
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 
-SNAPS = [opentelemetry_collector_snap_name, node_exporter_snap_name]
+
+def hook() -> str:
+    """Return Juju hook name."""
+    return os.environ["JUJU_HOOK_NAME"]
 
 
 class OpentelemetryCollectorOperatorCharm(ops.CharmBase):
@@ -34,11 +32,13 @@ class OpentelemetryCollectorOperatorCharm(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
+        if hook() == "install":
+            self._install()
+        if hook() == "stop":
+            self._stop()
         self._reconcile()
 
     def _reconcile(self):
-        self._install()
-        self._stop()
         # TODO: when removing the locking mechanism, change manager.get_revisions
         # to a free function, and use it to set to BlockedStatus on update-status
         # if the installed snap revision (max(get_revisions())) doesn't match the
@@ -46,74 +46,62 @@ class OpentelemetryCollectorOperatorCharm(ops.CharmBase):
         self.unit.status = ActiveStatus()
 
     def _install(self) -> None:
-        if self.hook != "install":
-            return
-
         manager = SingletonSnapManager(self.unit.name)
-        arch = get_system_arch()
 
-        for snap_package in SNAPS:
-            snap_revision = snap_maps[snap_package][("strict", arch)]
-            manager.register(snap_package, snap_revision)
-            with manager.snap_operation(snap_package):
-                if snap_revision > max(manager.get_revisions(snap_package)):
-                    self._install_snap(snap_package)
-                    self._start_snap(snap_package)
+        for snap_name in SnapMap.snaps():
+            snap_revision = SnapMap.get_revision(snap_name)
+            manager.register(snap_name, snap_revision)
+            if snap_revision > max(manager.get_revisions(snap_name)):
+                # Install the snap
+                self.unit.status = MaintenanceStatus(f"Installing {snap_name} snap")
+                install_snap(snap_name)
+                # Start the snap
+                self.unit.status = MaintenanceStatus(f"Starting {snap_name} snap")
+                try:
+                    self.snap(snap_name).start(enable=True)
+                except snap.SnapError as e:
+                    raise SnapServiceError(f"Failed to start {snap_name}") from e
 
-            with manager.config_operation(snap_package):
-                # Merge configurations under a directory into one,
-                # and write it to the default otelcol config file.
-                # This is a placeholder for actual configuration merging logic.
-                # For example:
-                #
-                # content = merge_config()
-                # with open('etc/otelcol/config.yaml', 'w') as f:
-                #     f.write(content)
-                #     f.flush()
-                pass
+            # Merge configurations under a directory into one,
+            # and write it to the default otelcol config file.
+            # This is a placeholder for actual configuration merging logic.
+            # For example:
+            #
+            # content = merge_config()
+            # with open('etc/otelcol/config.yaml', 'w') as f:
+            #     f.write(content)
+            #     f.flush()
+            pass
 
     def _stop(self) -> None:
-        if self.hook != "stop":
-            return
-
         manager = SingletonSnapManager(self.unit.name)
-        for snap_package in SNAPS:
-            manager.unregister(snap_package)
-            with manager.snap_operation(snap_package):
-                if not manager.is_used_by_other_units(snap_package):
-                    self._remove_snap(snap_package)
+        for snap_name in SnapMap.snaps():
+            snap_revision = SnapMap.get_revision(snap_name)
+            manager.unregister(snap_name, snap_revision)
+            if not manager.is_used_by_other_units(snap_name):
+                # Remove the snap
+                self.unit.status = MaintenanceStatus(f"Uninstalling {snap_name} snap")
+                try:
+                    self.snap(snap_name).ensure(state=snap.SnapState.Absent)
+                except (snap.SnapError, SnapSpecError) as e:
+                    raise SnapInstallError(f"Failed to uninstall {snap_name}") from e
 
-    def _install_snap(self, snap_name: str) -> None:
-        self.unit.status = MaintenanceStatus(f"Installing {snap_name} snap")
-        try:
-            install_snap(snap_name)
-        except (snap.SnapError, SnapSpecError) as e:
-            raise SnapInstallError(f"Failed to install {snap_name}") from e
+    def snap(self, snap_name: str) -> snap.Snap:
+        """Return the snap object for the given snap.
 
-    def _remove_snap(self, snap_name: str) -> None:
-        self.unit.status = MaintenanceStatus(f"Uninstalling {snap_name} snap")
-        try:
-            self.snap(snap_name).ensure(state=snap.SnapState.Absent)
-        except (snap.SnapError, SnapSpecError) as e:
-            raise SnapInstallError(f"Failed to uninstall {snap_name}") from e
+        This method provides lazy initialization of snap objects, avoiding unnecessary
+        calls to snapd until they're actually needed.
 
-    def _start_snap(self, snap_name: str) -> None:
-        self.unit.status = MaintenanceStatus(f"Starting {snap_name} snap")
+        Args:
+            snap_name: Name of the snap to retrieve
 
-        try:
-            self.snap(snap_name).start(enable=True)
-        except snap.SnapError as e:
-            raise SnapServiceError(f"Failed to start {snap_name}") from e
+        Returns:
+            The Snap object for the requested snap
 
-    def snap(self, snap_name: str):
-        """Return the snap object for the given snap."""
-        # This is handled in a property to avoid calls to snapd until they're necessary.
+        Raises:
+            snap.SnapError: If there's an error accessing the snap
+        """
         return snap.SnapCache()[snap_name]
-
-    @property
-    def hook(self) -> str:
-        """Return hook name."""
-        return os.environ["JUJU_HOOK_NAME"]
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/singleton_snap.py
+++ b/src/singleton_snap.py
@@ -62,13 +62,66 @@ For testing, this directory is patched to a temporary location.
      (such as Windows), you may need to adapt the locking mechanism.
 """
 
-import fcntl
+from dataclasses import dataclass
 import os
 import re
-import time
-from contextlib import contextmanager
-from typing import Generator, List
+from typing import Set
 import errno
+
+
+@dataclass
+class SnapRegistrationFile:
+    """Registration file for tracking snap registrations by units.
+
+    The files are stored in the lock directory and follow a specific naming convention.
+
+    The filename format is: LCK..<snap_name>__<revision>--<unit_name>
+    Example: LCK..opentelemetry-collector__10--otelcol-0
+
+    Attributes:
+        unit_name: Name of the unit registering the snap
+        snap_name: Name of the snap being registered
+        snap_revision: Revision of the snap being registered
+    """
+
+    unit_name: str
+    snap_name: str
+    snap_revision: int
+
+    PREFIX = "LCK.."
+    SEPARATOR_REVISION = "__"
+    SEPARATOR_UNIT = "--"
+
+    @property
+    def filename(self):
+        """Assemble the filename."""
+        return (
+            f"{self.PREFIX}"
+            f"{self.snap_name}"
+            f"{self.SEPARATOR_REVISION}"
+            f"{str(self.snap_revision)}"
+            f"{self.SEPARATOR_UNIT}"
+            f"{SnapRegistrationFile._normalize_name(self.unit_name)}"
+        )
+
+    @staticmethod
+    def from_filename(filename: str):
+        """Build a SnapRegistrationFile by parsing its filename."""
+        # Remove the PREFIX
+        _, filename = filename.split(SnapRegistrationFile.PREFIX)
+        # Extract the information one by one
+        snap_name, filename = filename.split(SnapRegistrationFile.SEPARATOR_REVISION)
+        snap_revision, unit_name = filename.split(SnapRegistrationFile.SEPARATOR_UNIT)
+        return SnapRegistrationFile(
+            unit_name=unit_name,
+            snap_name=snap_name,
+            snap_revision=int(snap_revision),
+        )
+
+    @staticmethod
+    def _normalize_name(name: str) -> str:
+        """Normalize names to contain only alphanumerics, _ and -."""
+        return re.sub(r"[^\w-]", "_", name)
 
 
 class SingletonSnapManager:
@@ -82,17 +135,6 @@ class SingletonSnapManager:
     Usage:
 
     .. code-block:: python
-
-        # For snap operations
-        with manager.snap_operation("otelcol", timeout=30):
-            # Exclusive snap install/remove operations here.
-            pass
-
-        # For configuration changes
-        with manager.config_operation("/etc/otelcol/config.yaml"):
-            # Safe config file modifications here.
-            pass
-
         # For unit tracking
         manager.register("otelcol")
         # Use the snap...
@@ -105,8 +147,6 @@ class SingletonSnapManager:
         OSError: on I/O related errors.
     """
 
-    LOCK_FILE_PREFIX = "LCK.."
-    SEPARATOR = "--"
     LOCK_DIR = "/run/lock/singleton_snaps"
 
     def __init__(self, unit_name: str):
@@ -115,13 +155,8 @@ class SingletonSnapManager:
         Args:
             unit_name: Identifier for the current unit
         """
-        self.unit_name = self._normalize_name(unit_name)
+        self.unit_name = unit_name
         self._ensure_lock_dir_exists()
-
-    @staticmethod
-    def _normalize_name(name: str) -> str:
-        """Normalize names to contain only alphanumerics, _ and -."""
-        return re.sub(r"[^\w-]", "_", name)
 
     def _ensure_lock_dir_exists(self) -> None:
         """Ensure the lock directory exists with correct permissions."""
@@ -132,36 +167,38 @@ class SingletonSnapManager:
             if e.errno != errno.EEXIST:
                 raise
 
-    def _get_registration_file_path(self, snap_name: str) -> str:
-        """Helper method to construct registration file path.
-
-        The registration file name is constructed as:
-        LCK..{snap_name}--{unit_name}
-        """
-        filename = f"{self.LOCK_FILE_PREFIX}{snap_name}{self.SEPARATOR}{self.unit_name}"
-        return os.path.join(self.LOCK_DIR, filename)
-
-    def _parse_unit_name_from_file(self, filename: str, snap_name: str) -> str:
-        """Helper method to extract unit name from registration filename."""
-        prefix = f"{self.LOCK_FILE_PREFIX}{snap_name}{self.SEPARATOR}"
-        return filename[len(prefix) :]
-
-    def register(self, snap_name: str, revision: int) -> None:
+    def register(self, snap_name: str, snap_revision: int) -> None:
         """Register current unit as using the specified snap and revision.
 
         Args:
             snap_name: Name of the snap.
-            revision: Optional revision to put in the lock file. Defaults to an empty string.
+            snap_revision: Optional revision to put in the lock file. Defaults to an empty string.
 
         Raises:
             OSError: if there is an I/O related error creating the lock file.
         """
-        lock_path = self._get_registration_file_path(snap_name)
-        with self._lock_directory():
-            with open(lock_path, "w") as f:
-                f.write(str(revision))
+        registration_file = SnapRegistrationFile(
+            unit_name=self.unit_name,
+            snap_name=snap_name,
+            snap_revision=snap_revision,
+        )
+        with open(registration_file.filename, "w") as f:
+            f.write(str(snap_revision))
 
-    def get_revisions(self, snap_name: str) -> List[int]:
+    def unregister(self, snap_name: str, snap_revision: int) -> None:
+        """Unregister current unit from using the specified snap.
+
+        Raises:
+            OSError: if there is an I/O related error removing the lock file.
+        """
+        registration_file = SnapRegistrationFile(
+            unit_name=self.unit_name,
+            snap_name=snap_name,
+            snap_revision=snap_revision,
+        )
+        os.remove(registration_file.filename)
+
+    def get_revisions(self, snap_name: str) -> Set[int]:
         """Get all revisions of a snap currently registered with any unit.
 
         Args:
@@ -173,42 +210,20 @@ class SingletonSnapManager:
         Raises:
             OSError: If there's an error accessing the lock directory or files.
         """
-        prefix = f"{self.LOCK_FILE_PREFIX}{snap_name}{self.SEPARATOR}"
         revisions = set()
-        with self._lock_directory():
-            for filename in os.listdir(self.LOCK_DIR):
-                if filename.startswith(prefix):
-                    path = os.path.join(self.LOCK_DIR, filename)
-                    try:
-                        with open(path, "r") as f:
-                            revision = f.read().strip()
-                            if revision:
-                                revisions.add(int(revision))
-                    except OSError:
-                        continue
-        return list(revisions)
+        for filename in os.listdir(self.LOCK_DIR):
+            registration_file = SnapRegistrationFile.from_filename(filename)
+            if registration_file.snap_name == snap_name:
+                path = os.path.join(self.LOCK_DIR, filename)
+                try:
+                    with open(path, "r") as f:
+                        revision = f.read().strip()
+                        revisions.add(int(revision))
+                except OSError:
+                    continue
+        return revisions
 
-    def unregister(self, snap_name: str) -> None:
-        """Unregister current unit from using the specified snap.
-
-        Raises:
-            OSError: if there is an I/O related error removing the lock file.
-        """
-        lock_path = self._get_registration_file_path(snap_name)
-        with self._lock_directory():
-            os.remove(lock_path)
-
-    @contextmanager
-    def _lock_directory(self):
-        dir_fd = os.open(self.LOCK_DIR, os.O_RDONLY)
-        try:
-            fcntl.flock(dir_fd, fcntl.LOCK_SH)
-            yield
-        finally:
-            fcntl.flock(dir_fd, fcntl.LOCK_UN)
-            os.close(dir_fd)
-
-    def get_units(self, snap_name: str) -> List[str]:
+    def get_units(self, snap_name: str) -> Set[str]:
         """Get all units currently registered for a snap (atomic with directory lock).
 
         This method is primarily useful for debugging purposes. In most scenarios, you
@@ -220,87 +235,30 @@ class SingletonSnapManager:
             snap_name: Name of the snap to get units for
 
         Returns:
-            List of unit names associated with the snap
+            Set of unit names associated with the snap
 
         Raises:
             OSError: If there's an error accessing the lock directory
         """
-        prefix = f"{self.LOCK_FILE_PREFIX}{self._normalize_name(snap_name)}{self.SEPARATOR}"
-        units = []
+        units = set()
 
-        with self._lock_directory():
-            for filename in os.listdir(self.LOCK_DIR):
-                if filename.startswith(prefix):
-                    units.append(filename[len(prefix) :])
+        for filename in os.listdir(self.LOCK_DIR):
+            registration_file = SnapRegistrationFile.from_filename(filename)
+            if registration_file.snap_name == snap_name:
+                units.add(registration_file.unit_name)
 
         return units
 
     def is_used_by_other_units(self, snap_name: str) -> bool:
-        """Check if snap is being used by other units."""
+        """Check if the specified snap is being used by other units.
+
+        Args:
+            snap_name: Name of the snap to check
+
+        Returns:
+            bool: True if the snap is used by other units, False otherwise
+
+        Raises:
+            OSError: If there's an error accessing the lock directory
+        """
         return any(unit != self.unit_name for unit in self.get_units(snap_name))
-
-    @contextmanager
-    def _acquire_lock(self, lock_name: str, timeout: float) -> Generator[None, None, None]:
-        """Internal method to acquire an exclusive lock with timeout.
-
-        Uses fcntl.flock to acquire an exclusive lock on a lock file.
-        Retries until the timeout is reached.
-
-        Raises:
-            TimeoutError: If the lock could not be acquired within the specified timeout.
-            OSError: If an error occurs while unlocking or removing the lock file.
-        """
-        lock_path = os.path.join(self.LOCK_DIR, f"{self.LOCK_FILE_PREFIX}{lock_name}")
-        with open(lock_path, "w") as f:
-            deadline = time.monotonic() + timeout
-            while True:
-                try:
-                    fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    break
-                except BlockingIOError:
-                    if time.monotonic() > deadline:
-                        raise TimeoutError(f"Timeout acquiring lock for {lock_name}")
-                    time.sleep(0.1)
-            try:
-                yield
-            finally:
-                fcntl.flock(f, fcntl.LOCK_UN)
-                try:
-                    os.remove(lock_path)
-                except FileNotFoundError:
-                    pass
-                except OSError:
-                    raise
-
-    @contextmanager
-    def snap_operation(self, snap_name: str, timeout: float = 30.0) -> Generator[None, None, None]:
-        """Context manager for exclusive snap operations (install/remove/configure).
-
-        Example:
-            with manager.snap_operation('otelcol'):
-                # perform privileged snap operations
-
-        Raises:
-            TimeoutError: If the lock could not be acquired within the specified timeout.
-            OSError: If an error occurs while unlocking or removing the lock file.
-        """
-        with self._acquire_lock(self._normalize_name(snap_name), timeout):
-            yield
-
-    @contextmanager
-    def config_operation(
-        self, config_path: str, timeout: float = 3.0
-    ) -> Generator[None, None, None]:
-        """Context manager for exclusive configuration file operations.
-
-        Example:
-            with manager.config_operation('/etc/config.yaml'):
-                # safely modify configuration
-
-        Raises:
-            TimeoutError: If the lock could not be acquired within the specified timeout.
-            OSError: If an error occurs while unlocking or removing the lock file.
-        """
-        normalized = self._normalize_name(config_path.replace("/", "_"))
-        with self._acquire_lock(f"config_{normalized}", timeout):
-            yield

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -1,102 +1,19 @@
-#!/usr/bin/env python3
-
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-
-# Learn more at: https://juju.is/docs/sdk
-
 """Snap Installation Module.
 
 Modified from https://github.com/canonical/k8s-operator/blob/main/charms/worker/k8s/src/snap.py
 """
 
+from dataclasses import dataclass
 import logging
 import platform
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
 
 import charms.operator_libs_linux.v2.snap as snap_lib
 from charms.operator_libs_linux.v2.snap import JSONAble
 
-# Log messages can be retrieved using juju debug-log
 log = logging.getLogger(__name__)
-
-
-opentelemetry_collector_snap_name = "opentelemetry-collector"
-node_exporter_snap_name = "node-exporter"
-
-snap_maps = {
-    opentelemetry_collector_snap_name: {
-        # (confinement, arch): revision
-        ("strict", "amd64"): 9,  # 0.119.0
-        ("strict", "arm64"): 10,  # 0.119.0
-    },
-    node_exporter_snap_name: {
-        # (confinement, arch): revision
-        ("strict", "amd64"): 1904,  # v1.9.1
-        ("strict", "arm64"): 1908,  # v1.9.1
-    },
-}
-
-
-class SnapSpecError(Exception):
-    """Custom exception type for errors related to the snap spec."""
-
-    pass
-
-
-class SnapError(Exception):
-    """Custom exception type for Snaps."""
-
-    pass
-
-
-class SnapInstallError(SnapError):
-    """Custom exception type for install related errors."""
-
-    pass
-
-
-class SnapServiceError(SnapError):
-    """Custom exception type for service related errors."""
-
-    pass
-
-
-def install_snap(snap: str, classic: bool = False, config: Optional[Dict[str, JSONAble]] = None):
-    """Looks up system details and installs the appropriate snap revision."""
-    arch = get_system_arch()
-    confinement = "classic" if classic else "strict"
-
-    try:
-        revision = snap_maps[snap][(confinement, arch)]
-    except KeyError as e:
-        raise SnapSpecError(
-            f"{snap} snap spec not found for arch={arch} and confinement={confinement}"
-        ) from e
-
-    _install_snap(name=snap, revision=revision, classic=classic, config=config)
-
-
-def _install_snap(
-    name: str,
-    revision: int,
-    classic: bool = False,
-    config: Optional[Dict[str, JSONAble]] = None,
-):
-    """Install and pin the given snap revision.
-
-    The revision will be held, i.e. it won't be automatically updated any time a new revision is released.
-    """
-    cache = snap_lib.SnapCache()
-    snap = cache[name]
-    log.info(
-        f"Ensuring {name} snap is installed at revision={revision}"
-        f" with classic confinement={classic}"
-    )
-    snap.ensure(state=snap_lib.SnapState.Present, revision=str(revision), classic=classic)
-    if config:
-        snap.set(config)
-    snap.hold()
 
 
 def get_system_arch() -> str:
@@ -112,3 +29,107 @@ def get_system_arch() -> str:
         arch = "arm64"
     # else: keep arch as is
     return arch
+
+
+@dataclass
+class SnapMap:
+    """Maps snap revisions based on architecture and confinement mode.
+
+    This class maintains a mapping of snap revisions for different combinations
+    of architecture and confinement mode. It's used to determine the correct
+    revision of a snap to install based on the system's architecture and the
+    desired confinement mode.
+    """
+
+    snap_maps = {
+        "opentelemetry-collector": {
+            # (confinement, arch): revision
+            ("strict", "amd64"): 9,  # 0.119.0
+            ("strict", "arm64"): 10,  # 0.119.0
+        },
+        "node-exporter": {
+            # (confinement, arch): revision
+            ("strict", "amd64"): 1904,  # v1.9.1
+            ("strict", "arm64"): 1908,  # v1.9.1
+        },
+    }
+
+    @staticmethod
+    def get_revision(snap_name: str, classic: bool = False, arch: str = get_system_arch()) -> int:
+        """Get the target revision of a snap based on confinement and arch."""
+        confinement = "classic" if classic else "strict"
+        return SnapMap.snap_maps[snap_name][(confinement, arch)]
+
+    @staticmethod
+    def snaps() -> Set[str]:
+        """Return a Set with all the snap names managed by the map."""
+        return set(SnapMap.snap_maps.keys())
+
+
+class SnapSpecError(Exception):
+    """Raised when there's an error with the snap specification.
+
+    This exception is raised when a requested snap or revision is not found
+    in the SnapMap for the current system configuration.
+    """
+
+
+class SnapError(Exception):
+    """Base exception for all snap-related errors."""
+
+
+class SnapInstallError(SnapError):
+    """Raised when there's an error installing a snap."""
+
+
+class SnapServiceError(SnapError):
+    """Raised when there's an error managing a snap service.
+
+    This exception is raised when there's an error starting, stopping,
+    or otherwise managing a snap's service.
+    """
+
+
+def install_snap(
+    snap_name: str,
+    classic: bool = False,
+    config: Optional[Dict[str, JSONAble]] = None,
+) -> None:
+    """Install a snap and pin it to a specific revision.
+
+    This function installs the specified snap, configures it according to the
+    provided parameters, and pins it to prevent automatic updates. The revision
+    is determined based on the system architecture and requested confinement mode,
+    as defined in the SnapMap.
+
+    Args:
+        snap_name: Name of the snap to install (e.g., 'opentelemetry-collector')
+        classic: If True, uses classic confinement. Defaults to False for strict confinement.
+        config: Optional dictionary of configuration options to apply to the snap.
+               The keys should be valid configuration options for the snap.
+
+    Raises:
+        SnapSpecError: If the snap or revision is not found in the SnapMap
+        SnapInstallError: If there's an error during installation or configuration
+        snap.SnapError: For errors from the underlying snap management library
+    """
+    # Check whether we have a spec in the SnapMap
+    try:
+        revision = SnapMap.get_revision(snap_name, classic=classic)
+    except KeyError as e:
+        raise SnapSpecError(
+            f"Failed to install snap {snap_name}: "
+            f"snap spec not found for arch={get_system_arch()} "
+            f"and confinement={'classic' if classic else 'strict'}"
+        ) from e
+    # Install the Snap
+    cache = snap_lib.SnapCache()
+    snap = cache[snap_name]
+    log.info(
+        f"Ensuring {snap_name} snap is installed at revision={revision}"
+        f" with confinement={'classic' if classic else 'strict'}"
+    )
+    snap.ensure(state=snap_lib.SnapState.Present, revision=str(revision), classic=classic)
+    if config:
+        snap.set(config)
+    snap.hold()

--- a/tests/unit/test_singleton_snap.py
+++ b/tests/unit/test_singleton_snap.py
@@ -131,9 +131,9 @@ def test_lock_timeout(lock_dir):
     with pytest.raises(TimeoutError):
         with mgr2.snap_operation("otelcol", timeout=1):
             pass
-    assert (
-        time.time() - start >= 1
-    ), "Second, conflicting lockmgr wrongfully succeeded to grab the lock before it was released by the first lockmgr."
+    assert time.time() - start >= 1, (
+        "Second, conflicting lockmgr wrongfully succeeded to grab the lock before it was released by the first lockmgr."
+    )
 
     p.join()
 


### PR DESCRIPTION
## Issue
Closes #12 


## Solution
This PR not only removes the locking mechanism, but also simplifies the snap management process and makes it more robust. 

In preparation of the config management logic, the snap revision was added to the filename; in a future PR we'll probably not write it inside the file as well (as that might hold the workload config).

I kept the `hook` matching logic and just made it more visible, even though I'm not sure whether we should keep it or not (in any case, it wouldn't be changed in this PR).

