### PR TITLE
feat: add some tests to the vm charm

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -245,7 +245,7 @@ class ConfigBuilder:
                     self._add_to_pipeline("debug", Component.exporter, [signal])
                     debug_exporter_required = True
         if debug_exporter_required:
-            self.add_component(Component.exporter, "debug", {"verbosity": "basic"})
+            self.add_component(Component.exporter, "debug", {"verbosity": "normal"})
 
     def _add_tls_to_all_receivers(
         self,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Conftest file for integration tests."""
+
+import functools
+import logging
+import os
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+import jubilant
+
+logger = logging.getLogger(__name__)
+
+store = defaultdict(str)
+
+
+def timed_memoizer(func):
+    """Cache the result of a function."""
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        fname = func.__qualname__
+        logger.info("Started: %s" % fname)
+        start_time = datetime.now()
+        if fname in store.keys():
+            ret = store[fname]
+        else:
+            logger.info("Return for {} not cached".format(fname))
+            ret = await func(*args, **kwargs)
+            store[fname] = ret
+        logger.info("Finished: {} in: {} seconds".format(fname, datetime.now() - start_time))
+        return ret
+
+    return wrapper
+
+
+@pytest.fixture(scope="module")
+@timed_memoizer
+async def charm(ops_test: OpsTest) -> str:
+    """Charm used for integration testing.
+
+    When multiple charm files (i.e., for different bases) are produced by a `charmcraft pack`,
+    our CI will currently set the variable to the highest-base one.
+    """
+    if charm_file := os.environ.get("CHARM_PATH"):
+        # Make sure we're using '22.04' in tests, because that's Zookeeper's base
+        charm_file = charm_file.replace("24.04", "22.04")
+        return str(charm_file)
+
+    charm = await ops_test.build_charm(".")
+    assert charm
+    return str(charm)
+
+
+@pytest.fixture(scope="module")
+def juju():
+    keep_models: bool = os.environ.get("KEEP_MODELS") is not None
+    with jubilant.temp_model(keep=keep_models) as juju:
+        yield juju

--- a/tests/integration/test_cos_agent.py
+++ b/tests/integration/test_cos_agent.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Feature: COS Agent integration works as expected."""
+
+import pathlib
+import re
+from typing import Dict
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+import jubilant
+
+# Juju is a strictly confined snap that cannot see /tmp, so we need to use something else
+TEMP_DIR = pathlib.Path(__file__).parent.resolve()
+
+
+@retry(stop=stop_after_attempt(60), wait=wait_fixed(10))
+async def is_pattern_in_logs(juju: jubilant.Juju, pattern: str):
+    otelcol_logs = juju.ssh("otelcol/0", command="sudo snap logs opentelemetry-collector -n=1000")
+    match = re.search(pattern, otelcol_logs)
+    return match is not None
+
+
+async def test_deploy(juju: jubilant.Juju, charm: str):
+    # GIVEN an OpenTelemetry Collector charm and a principal
+    juju.deploy(charm, app="otelcol")
+    juju.deploy("zookeeper", channel="3/stable")
+    # WHEN they are related
+    juju.integrate("otelcol:cos-agent", "zookeeper:cos-agent")
+    # THEN all units are active
+    # FIXME: after we add blocked status on missing relations (mandatory pairs), change this
+    juju.wait(jubilant.all_active, timeout=300)
+
+
+async def test_metrics(juju: jubilant.Juju):
+    metrics_pattern = rf".+{{.*juju_application=zookeeper,.*juju_model={juju.model}.*}}"
+    result = await is_pattern_in_logs(juju, metrics_pattern)
+    return result
+
+
+async def test_logs(juju: jubilant.Juju):
+    logs_pattern = r".+log.file.name=zookeeper.log.+log.file.path=/snap/opentelemetry-collector/\d+/shared-logs/zookeeper"
+    result = await is_pattern_in_logs(juju, logs_pattern)
+    return result


### PR DESCRIPTION
## Issue
The machine charm is lacking any kind of testing.


## Solution
This PR adds the following:
- an integration test covering `cos-agent` metrics and logs integrations


### Drive-by changes

- charm class renamed from `OpentelemetryCollectorCharmOperator` to `OpenTelemetryCollectorCharm`, to be in line with the k8s naming
- debug exporter verbosity changed to `normal`, to allow for integration testing without needing a k8s model
