### PR TITLE
feat: scrape node-exporter metrics

### DIFF
--- a/tests/integration/test_principal.py
+++ b/tests/integration/test_principal.py
@@ -54,3 +54,9 @@ async def test_path_exclude(juju: jubilant.Juju):
     assert is_included
     is_excluded = await is_pattern_not_in_logs(juju, excluded_log_pattern)
     assert is_excluded
+
+
+async def test_node_metrics(juju: jubilant.Juju):
+    node_metric = r"node_scrape_collector_success"
+    is_included = await is_pattern_in_logs(juju, node_metric)
+    assert is_included


### PR DESCRIPTION
## Issue
`node-exporter` metrics are currently not being scraped.


## Solution
Scrape the metrics. Checked via the `test_principal.py` integration test.

I'm aware the reconciler method is becoming big again, but I'd like to do a follow-up PR (possibly extracting functions into an `integrations_machine.py` file) to cleanly separate the cos-agent integration from the shared integrations. This PR however, shall stay small!


## Context
Feature-parity with grafana-agent.

