### PR TITLE
feat: Status message on missing relation pairs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -371,6 +371,11 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
 
         self.unit.status = ActiveStatus()
 
+        # Mandatory relation pairs
+        missing_relations = integrations.get_missing_mandatory_relations(self)
+        if missing_relations:
+            self.unit.status = BlockedStatus(missing_relations)
+
     def _install(self) -> None:
         manager = SingletonSnapManager(self.unit.name)
 

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -38,7 +38,7 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     Mode,
     TLSCertificatesRequiresV4,
 )
-from cosl import LZMABase64
+from cosl import LZMABase64, MandatoryRelationPairs
 from ops import CharmBase, tracing
 from ops.model import Relation
 
@@ -480,3 +480,39 @@ def receive_ca_cert(
 
     # A hot-reload doesn't pick up new system certs - need to restart the service
     return sha256(yaml.safe_dump(ca_certs))
+
+
+def get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
+    """Check whether mandatory relations are in place.
+
+    The charm can use this information to set BlockedStatus.
+    Without any matching outgoing relation, the collector could incur data loss.
+    Incoming relations are evaluated with AND, while outgoing relations with OR.
+
+    Returns:
+        A string containing the missing relations in string format, or None if
+        all the mandatory relation pairs are present.
+    """
+    relation_pairs = MandatoryRelationPairs(
+        pairs={
+            "metrics-endpoint": [  # must be paired with:
+                {"send-remote-write"},  # or
+                {"cloud-config"},
+            ],
+            "receive-loki-logs": [  # must be paired with:
+                {"send-loki-logs"},  # or
+                {"cloud-config"},
+            ],
+            "receive-traces": [  # must be paired with:
+                {"send-traces"},  # or
+                {"cloud-config"},
+            ],
+            "grafana-dashboards-consumer": [  # must be paired with:
+                {"grafana-dashboards-provider"},  # or
+                {"cloud-config"},
+            ],
+        }
+    )
+    active_relations = {name for name, relation in charm.model.relations.items() if relation}
+    missing_str = relation_pairs.get_missing_as_str(*active_relations)
+    return missing_str or None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,13 +47,19 @@ async def charm(ops_test: OpsTest) -> str:
     our CI will currently set the variable to the highest-base one.
     """
     if charm_file := os.environ.get("CHARM_PATH"):
-        # Make sure we're using '22.04' in tests, because that's Zookeeper's base
-        charm_file = charm_file.replace("24.04", "22.04")
-        return str(charm_file)
+        return charm_file
 
     charm = await ops_test.build_charm(".")
     assert charm
     return str(charm)
+
+
+@pytest.fixture(scope="module")
+@timed_memoizer
+async def charm_22_04(charm) -> str:
+    """Charm (platform = ubuntu@22.04) used for integration testing."""
+    # Note: Use '22.04' in integration tests with Zookeeper, because that's Zookeeper's base
+    return charm.replace("24.04", "22.04")
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_cos_agent.py
+++ b/tests/integration/test_cos_agent.py
@@ -21,9 +21,9 @@ async def is_pattern_in_logs(juju: jubilant.Juju, pattern: str):
     return True
 
 
-async def test_deploy(juju: jubilant.Juju, charm: str):
+async def test_deploy(juju: jubilant.Juju, charm_22_04: str):
     # GIVEN an OpenTelemetry Collector charm and a principal
-    juju.deploy(charm, app="otelcol")
+    juju.deploy(charm_22_04, app="otelcol")
     juju.deploy("zookeeper", channel="3/stable")
     # WHEN they are related
     juju.integrate("otelcol:cos-agent", "zookeeper:cos-agent")

--- a/tests/integration/test_principal.py
+++ b/tests/integration/test_principal.py
@@ -29,10 +29,10 @@ async def is_pattern_not_in_logs(juju: jubilant.Juju, pattern: str):
     return True
 
 
-async def test_deploy(juju: jubilant.Juju, charm: str):
+async def test_deploy(juju: jubilant.Juju, charm_22_04: str):
     # GIVEN an OpenTelemetry Collector charm and a principal
     ## NOTE: /var/log/cloud-init.log and /var/log/cloud-init-output.log are always present
-    juju.deploy(charm, app="otelcol", config={"path_exclude": "/var/log/cloud-init-output.log"})
+    juju.deploy(charm_22_04, app="otelcol", config={"path_exclude": "/var/log/cloud-init-output.log"})
     juju.deploy("zookeeper", channel="3/stable")
     # WHEN they are related
     juju.integrate("otelcol:cos-agent", "zookeeper:cos-agent")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,6 +97,13 @@ def mock_singleton_snap_manager():
 
 
 @pytest.fixture(autouse=True)
+def mock_snap_map():
+    """Mock SnapMap methods."""
+    with patch("snap_management.SnapMap.get_revision", return_value=2):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def mock_cos_agent_update_tracing():
     """Mock the COS Agent's update_tracing_receivers method to prevent it from accessing the tracing attribute."""
     with patch(

--- a/tests/unit/test_mandatory_relation_pairs.py
+++ b/tests/unit/test_mandatory_relation_pairs.py
@@ -1,0 +1,34 @@
+from ops.testing import Relation, State
+from scenario import ActiveStatus, BlockedStatus
+
+
+def test_missing_relation_pair_status(ctx):
+    source_relation = Relation("metrics-endpoint")
+    # GIVEN the charm has no relations
+    state = State(
+        leader=True,
+        relations=[source_relation],  # source_relation must exist in state for relation_joined
+    )
+    # WHEN a source is related to opentelemetry-collector
+    state_out = ctx.run(ctx.on.relation_joined(source_relation), state)
+    # THEN the charm enters BlockedStatus
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    # AND the status message warns of the missing sink relations
+    assert "] for metrics-endpoint" in state_out.unit_status.message
+
+
+def test_valid_relation_pair_status(ctx):
+    source_relation = Relation("metrics-endpoint")
+    sink_relation = Relation("send-remote-write")
+    # GIVEN the charm has a source and no sink relation
+    state = State(
+        leader=True,
+        relations=[
+            source_relation,
+            sink_relation,
+        ],  # sink_relation must exist in state for relation_joined
+    )
+    # WHEN a sink is related to opentelemetry-collector
+    state_out = ctx.run(ctx.on.relation_joined(sink_relation), state)
+    # THEN the charm enters ActiveStatus
+    assert isinstance(state_out.unit_status, ActiveStatus)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/opentelemetry-collector-operator/issues/11

## Solution
<!-- A summary of the solution addressing the above issue -->
1. BlockedStatus if missing sink relations when a source relation exists.
2. We do not care if a sink relation exists without a source relation.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e unit -- tests/unit/test_mandatory_relation_pairs.py` 

## Upgrade Notes
<!-- To upgrade from an older revision of the charm, ... -->
