### PR TITLE
fix: change test_principal test to relate over juju-info

### DIFF
--- a/tests/integration/test_principal.py
+++ b/tests/integration/test_principal.py
@@ -39,7 +39,7 @@ async def test_deploy(juju: jubilant.Juju, charm_22_04: str):
     )
     juju.deploy("zookeeper", channel="3/stable")
     # WHEN they are related
-    juju.integrate("otelcol:cos-agent", "zookeeper:cos-agent")
+    juju.integrate("otelcol:juju-info", "zookeeper:juju-info")
     # THEN all units are active
     juju.wait(
         lambda status: jubilant.all_blocked(status, "otelcol"),


### PR DESCRIPTION
The `test_principal` test, unlike `test_cos_agent`, is meant to test the charm behavior when relating over `juju-info`, not `cos-agent`.

This PR fixes that.