### PR TITLE
feat: support multiple co-located principals configurations

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -238,7 +238,7 @@ class ConfigBuilder:
         exporters.
         """
         debug_exporter_required = False
-        for signal in ["logs", "metrics", "traces"]:
+        for signal in self._config["service"]["pipelines"].keys():
             pipeline = self._config["service"]["pipelines"].get(signal, {})
             if pipeline:
                 if pipeline.get("receivers", []) and not pipeline.get("exporters", []):

--- a/src/constants.py
+++ b/src/constants.py
@@ -7,7 +7,7 @@ SERVER_CERT_PATH: Final[str] = (
     "/var/snap/opentelemetry-collector/common/juju_tls-certificates/otelcol-server.crt"
 )
 SERVER_CERT_PRIVATE_KEY_PATH: Final[str] = "/var/snap/opentelemetry-collector/common/private.key"
-CONFIG_PATH: Final[str] = "/etc/otelcol/config.yaml"
+CONFIG_FOLDER: Final[str] = "/etc/otelcol/config.d"
 SERVICE_NAME: Final[str] = "otelcol"
 METRICS_RULES_SRC_PATH: Final[str] = "src/prometheus_alert_rules"
 METRICS_RULES_DEST_PATH: Final[str] = "prometheus_alert_rules"

--- a/src/singleton_snap.py
+++ b/src/singleton_snap.py
@@ -123,7 +123,7 @@ class SingletonSnapManager:
             snap_revision=snap_revision,
         )
         with open(self.LOCK_DIR.joinpath(registration_file.filename), "w") as f:
-            f.write(str(snap_revision))
+            f.write("")
 
     def unregister(self, snap_name: str, snap_revision: int) -> None:
         """Unregister current unit from using the specified snap.


### PR DESCRIPTION
## Issue
Closes #19.


## Solution
After https://github.com/canonical/opentelemetry-collector-snap/pull/29 , the snap uses all config files under `/etc/otelcol/config.d`.

- [ ] Upgrade the snap revision under `SnapMap` after merging the PR above.

