### PR TITLE
feat: Prometheus receiver global scrape interval and timeout

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -137,7 +137,7 @@ config:
         A global opentelemetry-collector "processors" config in YAML format, without the
         "processors:" top-level key. For example, to represent a "processors" section
         such as:
-        
+
             processors:
               batch:
               memory_limiter:
@@ -223,6 +223,18 @@ config:
         to this range by OpenTelemetry Collector.
       type: float
       default: 100.0
+    global_scrape_timeout:
+      description: >
+        How long to wait before timing out a scrape from a target.
+        Supported units: y, w, d, h, m, s.
+      type: string
+      default: "10s"
+    global_scrape_interval:
+      description: >
+        How frequently should instances be scraped.
+        Supported units: y, w, d, h, m, s.
+      type: string
+      default: "1m"
 
 actions:
   reconcile:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/opentelemetry-collector-operator/issues/39

## Solution
<!-- A summary of the solution addressing the above issue -->
Add config options for `global_scrape_interval` and `global_scrape_timeout`. Otel-collector's config is different from Grafana-agent's in the sense that it has not context of "global" config options. This option is only configurable at the receiver level, per `prometheus` receiver. For this reason, we have 2 possible approaches:
1. Make sure that each instance of the `add_component` for `prometheus` receiver has this properly implemented
2. Have a pre-render method in the config `build` method, which iterates over all `prometheus` receivers and updates the `global_scrape_interval` and `global_scrape_timeout`.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- `tox -e unit -- tests/unit/test_config_builder.py`