### PR TITLE
fix: Otelcol can exist as multiple subordinate units in the same machine

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -20,7 +20,7 @@ from ops import BlockedStatus, CharmBase, RelationChangedEvent
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 
 import integrations
-from config_builder import Component, Port
+from config_builder import Component
 from config_manager import ConfigManager
 from constants import (
     CONFIG_FOLDER,

--- a/src/charm.py
+++ b/src/charm.py
@@ -129,7 +129,11 @@ def _get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
 
 
 class OpenTelemetryCollectorCharm(ops.CharmBase):
-    """Charm the service."""
+    """Charm the service.
+
+    In machine charms we do not need to run self.unit.set_ports because the units are reachable via
+    the machine IP address.
+    """
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
@@ -390,10 +394,6 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         config_path = LocalPath(os.path.join(CONFIG_FOLDER, config_filename))
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(config_manager.config.build())
-
-        # Append port 9100 for Node Exporter # TODO: is this needed?
-        # if self.unit.is_leader():
-        #     self.unit.set_ports(*[port.value for port in Port])
 
         # If the config file or any cert has changed, a change in the hash
         # will trigger a restart

--- a/src/charm.py
+++ b/src/charm.py
@@ -389,8 +389,8 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         config_path.write_text(config_manager.config.build())
 
         # Append port 9100 for Node Exporter # TODO: is this needed?
-        if self.unit.is_leader():
-            self.unit.set_ports(*[port.value for port in Port])
+        # if self.unit.is_leader():
+        #     self.unit.set_ports(*[port.value for port in Port])
 
         # If the config file or any cert has changed, a change in the hash
         # will trigger a restart

--- a/tests/integration/test_removal_hooks.py
+++ b/tests/integration/test_removal_hooks.py
@@ -42,7 +42,8 @@ async def test_unit_is_reachable_from_outside(juju: jubilant.Juju):
     # GIVEN a subordinate otelcol unit
     unit_address = juju.status().get_units("otelcol")["otelcol/0"].public_address
     # THEN the workload is reachable from the unit IP address
-    assert "Server available" in sh.curl(f"http://{unit_address}:{Port.health.value}")
+    health = sh.curl(f"http://{unit_address}:{Port.health.value}")  # type: ignore
+    assert "Server available" in health
 
 
 async def test_remove_one_principal_one_machine(juju: jubilant.Juju):

--- a/tests/integration/test_removal_hooks.py
+++ b/tests/integration/test_removal_hooks.py
@@ -116,12 +116,12 @@ async def test_remove_two_principals_two_machines(juju: jubilant.Juju):
     juju.wait(
         lambda status: jubilant.all_blocked(status, "otelcol"),
         error=jubilant.any_error,
-        timeout=480,
+        timeout=600,
     )
     juju.wait(
         lambda status: jubilant.all_active(status, "zookeeper"),
         error=jubilant.any_error,
-        timeout=480,
+        timeout=600,
     )
 
     # WHEN the relation is removed
@@ -129,14 +129,14 @@ async def test_remove_two_principals_two_machines(juju: jubilant.Juju):
     juju.wait(
         lambda status: jubilant.all_active(status, "zookeeper"),
         error=jubilant.any_error,
-        timeout=240,
+        timeout=360,
     )
 
     # THEN Otelcol has "unknown" status and a scale of 0
     juju.wait(
         lambda status: status.apps["otelcol"].app_status.current == "unknown",
         error=jubilant.any_error,
-        timeout=240,
+        timeout=360,
     )
     assert juju.status().get_units("otelcol") == {}
 

--- a/tests/integration/test_removal_hooks.py
+++ b/tests/integration/test_removal_hooks.py
@@ -69,12 +69,12 @@ async def test_remove_two_principals_one_machine(juju: jubilant.Juju):
     juju.wait(
         lambda status: jubilant.all_blocked(status, "otelcol"),
         error=jubilant.any_error,
-        timeout=240,
+        timeout=360,
     )
     juju.wait(
         lambda status: jubilant.all_active(status, "ubuntu"),
         error=jubilant.any_error,
-        timeout=240,
+        timeout=360,
     )
 
     # WHEN the relation is removed
@@ -82,14 +82,14 @@ async def test_remove_two_principals_one_machine(juju: jubilant.Juju):
     juju.wait(
         lambda status: jubilant.all_active(status, "ubuntu"),
         error=jubilant.any_error,
-        timeout=360,
+        timeout=480,
     )
 
     # THEN Otelcol has "Blocked" with agent idle status
     juju.wait(
         lambda status: jubilant.all_blocked(status, "otelcol"),
         error=jubilant.any_error,
-        timeout=360,
+        timeout=480,
     )
     juju.wait(
         lambda status: jubilant.all_agents_idle(status, "otelcol"),

--- a/tests/integration/test_removal_hooks.py
+++ b/tests/integration/test_removal_hooks.py
@@ -13,23 +13,23 @@ from constants import CONFIG_FOLDER
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
 
 
-async def test_deploy(juju: jubilant.Juju, charm_22_04: str):
+async def test_deploy(juju: jubilant.Juju, charm: str):
     # GIVEN an OpenTelemetry Collector charm and a principal
     ## NOTE: /var/log/cloud-init.log and /var/log/cloud-init-output.log are always present
     juju.deploy(
-        charm_22_04, app="otelcol", config={"path_exclude": "/var/log/cloud-init-output.log"}
+        charm, app="otelcol", config={"path_exclude": "/var/log/cloud-init-output.log"}
     )
-    juju.deploy("zookeeper", channel="3/stable")
+    juju.deploy("grafana-cloud-integrator", base="ubuntu@22.04", channel="2/edge")
     # WHEN they are related
-    juju.integrate("otelcol:juju-info", "zookeeper:juju-info")
+    juju.integrate("otelcol:juju-info", "grafana-cloud-integrator:juju-info")
     # THEN all units are active
     juju.wait(
         lambda status: jubilant.all_blocked(status, "otelcol"),
         error=jubilant.any_error,
-        timeout=300,
+        timeout=600,
     )
     juju.wait(
-        lambda status: jubilant.all_active(status, "zookeeper"),
+        lambda status: jubilant.all_blocked(status, "grafana-cloud-integrator"),
         error=jubilant.any_error,
         timeout=600,
     )
@@ -39,9 +39,9 @@ async def test_remove_one_principal_one_machine(juju: jubilant.Juju):
     # GIVEN only 1 unit of the otelcol charm
     assert juju.status().get_units("otelcol").keys() == {"otelcol/0"}
     # WHEN the relation is removed
-    juju.remove_relation("otelcol:juju-info", "zookeeper:juju-info")
+    juju.remove_relation("otelcol:juju-info", "grafana-cloud-integrator:juju-info")
     juju.wait(
-        lambda status: jubilant.all_active(status, "zookeeper"),
+        lambda status: jubilant.all_blocked(status, "grafana-cloud-integrator"),
         error=jubilant.any_error,
         timeout=240,
     )
@@ -56,14 +56,14 @@ async def test_remove_one_principal_one_machine(juju: jubilant.Juju):
 
     # AND there is no otelcol config file on disk
     otelcol_config = juju.ssh(
-        "zookeeper/0", command=f'test -e {CONFIG_FOLDER} || echo "does not exist"'
+        "grafana-cloud-integrator/0", command=f'test -e {CONFIG_FOLDER} || echo "does not exist"'
     )
     assert otelcol_config.strip() == "does not exist"
 
 
 async def test_remove_two_principals_one_machine(juju: jubilant.Juju):
     # GIVEN otelcol has 2 subordinate units on the same machine
-    juju.integrate("otelcol:juju-info", "zookeeper:juju-info")
+    juju.integrate("otelcol:juju-info", "grafana-cloud-integrator:juju-info")
     juju.deploy("ubuntu", base="ubuntu@22.04", to="0")
     juju.integrate("otelcol:juju-info", "ubuntu:juju-info")
     juju.wait(
@@ -102,29 +102,29 @@ async def test_remove_two_principals_one_machine(juju: jubilant.Juju):
 
     # AND the otelcol config file remains on disk
     otelcol_config = juju.ssh(
-        "zookeeper/0", command=f'test -e {CONFIG_FOLDER} || echo "does not exist"'
+        "grafana-cloud-integrator/0", command=f'test -e {CONFIG_FOLDER} || echo "does not exist"'
     )
     assert otelcol_config.strip() != "does not exist"
 
 
 async def test_remove_two_principals_two_machines(juju: jubilant.Juju):
     # GIVEN otelcol has 2 subordinate units on different machines
-    juju.add_unit("zookeeper", num_units=1)
+    juju.add_unit("grafana-cloud-integrator", num_units=1)
     juju.wait(
         lambda status: jubilant.all_blocked(status, "otelcol"),
         error=jubilant.any_error,
         timeout=600,
     )
     juju.wait(
-        lambda status: jubilant.all_active(status, "zookeeper"),
+        lambda status: jubilant.all_blocked(status, "grafana-cloud-integrator"),
         error=jubilant.any_error,
         timeout=600,
     )
 
     # WHEN the relation is removed
-    juju.remove_relation("otelcol:juju-info", "zookeeper:juju-info")
+    juju.remove_relation("otelcol:juju-info", "grafana-cloud-integrator:juju-info")
     juju.wait(
-        lambda status: jubilant.all_active(status, "zookeeper"),
+        lambda status: jubilant.all_blocked(status, "grafana-cloud-integrator"),
         error=jubilant.any_error,
         timeout=360,
     )
@@ -139,10 +139,10 @@ async def test_remove_two_principals_two_machines(juju: jubilant.Juju):
 
     # AND there are no otelcol config files on disk
     otelcol_config_0 = juju.ssh(
-        "zookeeper/0", command=f'test -e {CONFIG_FOLDER} || echo "does not exist"'
+        "grafana-cloud-integrator/0", command=f'test -e {CONFIG_FOLDER} || echo "does not exist"'
     )
     otelcol_config_1 = juju.ssh(
-        "zookeeper/1", command=f'test -e {CONFIG_FOLDER} || echo "does not exist"'
+        "grafana-cloud-integrator/1", command=f'test -e {CONFIG_FOLDER} || echo "does not exist"'
     )
     assert otelcol_config_0.strip() == "does not exist"
     assert otelcol_config_1.strip() == "does not exist"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/opentelemetry-collector-operator/issues/45

## Solution
Otelcol can exist as multiple subordinate units in the same machine, by removing the unit port assignments.

The [test_removal_hooks itest is passing](https://github.com/canonical/opentelemetry-collector-operator/actions/runs/16681807582/job/47222324125?pr=47), meaning that all our deployment scenarios work.

- [ ] Get final confirmation from charm-tech before merging

> [!WARNING]
> One downside to this implementation is without setting unit ports with:
>	- [ops.Unit.set\_ports](https://documentation.ubuntu.com/ops/latest/reference/ops/#ops.Unit.set_ports)
>	- [juju open-port](https://documentation.ubuntu.com/juju/3.6/reference/hook-command/list-of-hook-commands/open-port/#details)
>		- On public clouds the port will only be open while the application is exposed

> [!IMPORTANT]
> We are still able to query the unit from outside (on LXD VMs), e.g. `http://UNIT_IP:PORT`, when `PORT` is NOT defined with `ops.Unit.set_ports`.
