### PR TITLE
fix: reduce internal logging to WARN to avoid syslog explosion

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -299,7 +299,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             component=Component.receiver,
             name="filelog/var-log",
             config=_filelog_receiver_config(
-                include=["/var/log/**/*.log"],
+                include=["/var/log/**/*log"],
                 exclude=var_log_exclusions,
                 attributes={
                     "job": "opentelemetry-collector-var-log",
@@ -313,24 +313,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             ),
             pipelines=["logs"],
         )
-        config_manager.config.add_component(
-            component=Component.receiver,
-            name="filelog/syslog",
-            config=_filelog_receiver_config(
-                include=["/var/log/syslog"],
-                exclude=var_log_exclusions,
-                attributes={
-                    "job": "opentelemetry-collector-syslog",
-                    "juju_application": topology.application,
-                    "juju_unit": topology.unit,  # type: ignore
-                    "juju_charm": topology.charm_name,
-                    "juju_model": topology.model,
-                    "juju_model_uuid": topology.model_uuid,
-                    # NOTE: No snap_name attribute is necessary as these logs are not from a snap
-                },
-            ),
-            pipelines=["logs"],
-        )
+
         if self.unit.is_leader():
             integrations._add_alerts(
                 alerts=cos_agent.logs_alerts,

--- a/src/charm.py
+++ b/src/charm.py
@@ -299,10 +299,28 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             component=Component.receiver,
             name="filelog/var-log",
             config=_filelog_receiver_config(
-                include=["/var/log/**"],
+                include=["/var/log/**/*.log"],
                 exclude=var_log_exclusions,
                 attributes={
                     "job": "opentelemetry-collector-var-log",
+                    "juju_application": topology.application,
+                    "juju_unit": topology.unit,  # type: ignore
+                    "juju_charm": topology.charm_name,
+                    "juju_model": topology.model,
+                    "juju_model_uuid": topology.model_uuid,
+                    # NOTE: No snap_name attribute is necessary as these logs are not from a snap
+                },
+            ),
+            pipelines=["logs"],
+        )
+        config_manager.config.add_component(
+            component=Component.receiver,
+            name="filelog/syslog",
+            config=_filelog_receiver_config(
+                include=["/var/log/syslog"],
+                exclude=var_log_exclusions,
+                attributes={
+                    "job": "opentelemetry-collector-syslog",
                     "juju_application": topology.application,
                     "juju_unit": topology.unit,  # type: ignore
                     "juju_charm": topology.charm_name,

--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -162,7 +162,7 @@ class ConfigBuilder:
         # TODO https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
         # Add TLS config to extensions
         self.add_extension("health_check", {"endpoint": f"0.0.0.0:{Port.health.value}"})
-        self.add_telemetry("logs", {"level": "DEBUG"})
+        self.add_telemetry("logs", {"level": "WARN"})
         self.add_telemetry("metrics", {"level": "normal"})
 
     def add_component(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -65,8 +65,13 @@ async def charm(ops_test: OpsTest) -> str:
     original_text = '"level": "WARN"'
     modified_text = '"level": "INFO"'
     change_text_in_file(CONFIG_BUILDER_PATH, original_text, modified_text)
-    if charm_file := os.environ.get("CHARM_PATH"):
-        return charm_file
+
+    # FIXME: Avoid passing the charm file path as an environment variable,
+    #        so every time a test is executed a new charm is packed with the modification
+    #        in the internal telemetry level. This comment should be removed when then itest
+    #        are improved to not use internal telemetry to verify if otelcol is receiving logs and metrics
+    # if charm_file := os.environ.get("CHARM_PATH"):
+    #     return charm_file
 
     charm = await ops_test.build_charm(".")
     charm = str(charm).replace("24.04", "22.04")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ import logging
 import os
 from collections import defaultdict
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -16,6 +17,21 @@ import jubilant
 logger = logging.getLogger(__name__)
 
 store = defaultdict(str)
+
+CONFIG_BUILDER_PATH = Path(__file__).parent.parent.parent / "src" / "config_builder.py"
+
+
+def change_text_in_file(path: Path, original_text: str, replacement_text: str):
+    with open(path, "r") as f:
+        content = f.read()
+
+    if original_text not in content:
+        raise ValueError(f"'{original_text}' not found in '{path}'")
+
+    modified_content = content.replace(original_text, replacement_text, 1)
+
+    with open(path, "w") as f:
+        f.write(modified_content)
 
 
 def timed_memoizer(func):
@@ -46,11 +62,15 @@ async def charm(ops_test: OpsTest) -> str:
     When multiple charm files (i.e., for different bases) are produced by a `charmcraft pack`,
     our CI will currently set the variable to the highest-base one.
     """
+    original_text = '"level": "WARN"'
+    modified_text = '"level": "INFO"'
+    change_text_in_file(CONFIG_BUILDER_PATH, original_text, modified_text)
     if charm_file := os.environ.get("CHARM_PATH"):
         return charm_file
 
     charm = await ops_test.build_charm(".")
     charm = str(charm).replace("24.04", "22.04")
+    change_text_in_file(CONFIG_BUILDER_PATH, modified_text, original_text)
     assert charm
     return charm
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests helpers."""
+
+import re
+import jubilant
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+# FIXME: Reduce retry count once fixed
+# https://github.com/canonical/opentelemetry-collector-operator/issues/32
+
+@retry(stop=stop_after_attempt(10), wait=wait_fixed(5))
+async def is_pattern_in_snap_logs(juju: jubilant.Juju, grep_filters: list):
+    cmd = "sudo snap logs opentelemetry-collector -n=all" + " | " + " | ".join([f"grep {p}" for p in grep_filters])
+    otelcol_logs = juju.ssh("otelcol/0", command=cmd)
+
+    if not otelcol_logs:
+        raise Exception(f"Filters {grep_filters} not found in the otelcol logs")
+    return True
+
+@retry(stop=stop_after_attempt(25), wait=wait_fixed(10))
+async def is_pattern_not_in_logs(juju: jubilant.Juju, pattern: str):
+    otelcol_logs = juju.ssh("otelcol/0", command="sudo snap logs opentelemetry-collector -n=all")
+    if re.search(pattern, otelcol_logs):
+        raise Exception(f"Pattern {pattern} found in the otelcol logs")
+    return True

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,7 +10,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 # FIXME: Reduce retry count once fixed
 # https://github.com/canonical/opentelemetry-collector-operator/issues/32
 
-@retry(stop=stop_after_attempt(10), wait=wait_fixed(5))
+@retry(stop=stop_after_attempt(25), wait=wait_fixed(10))
 async def is_pattern_in_snap_logs(juju: jubilant.Juju, grep_filters: list):
     cmd = "sudo snap logs opentelemetry-collector -n=all" + " | " + " | ".join([f"grep {p}" for p in grep_filters])
     otelcol_logs = juju.ssh("otelcol/0", command=cmd)

--- a/tests/integration/test_cos_agent.py
+++ b/tests/integration/test_cos_agent.py
@@ -4,23 +4,12 @@
 """Feature: COS Agent integration works as expected."""
 
 import pathlib
-import re
 import jubilant
 from tenacity import retry, stop_after_attempt, wait_fixed
+from helpers import is_pattern_in_snap_logs
 
 # Juju is a strictly confined snap that cannot see /tmp, so we need to use something else
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
-
-
-# FIXME: Reduce retry count once fixed
-# https://github.com/canonical/opentelemetry-collector-operator/issues/32
-@retry(stop=stop_after_attempt(25), wait=wait_fixed(10))
-async def is_pattern_in_logs(juju: jubilant.Juju, pattern: str):
-    otelcol_logs = juju.ssh("otelcol/0", command="sudo snap logs opentelemetry-collector -n=all")
-    if not re.search(pattern, otelcol_logs):
-        raise Exception(f"Pattern {pattern} not found in the otelcol logs")
-    return True
-
 
 async def test_deploy(juju: jubilant.Juju, charm_22_04: str):
     # GIVEN an OpenTelemetry Collector charm and a principal
@@ -28,7 +17,7 @@ async def test_deploy(juju: jubilant.Juju, charm_22_04: str):
     juju.deploy("zookeeper", channel="3/stable")
     # WHEN they are related
     juju.integrate("otelcol:cos-agent", "zookeeper:cos-agent")
-    # THEN all units are active
+    # THEN all units are active/blocked
     juju.wait(
         lambda status: jubilant.all_blocked(status, "otelcol"),
         error=jubilant.any_error,
@@ -40,16 +29,18 @@ async def test_deploy(juju: jubilant.Juju, charm_22_04: str):
         timeout=600,
     )
 
-
 async def test_metrics_are_scraped(juju: jubilant.Juju):
-    metrics_pattern = rf".+{{.*juju_application=zookeeper,.*juju_model={juju.model}.*}}"
-    result = await is_pattern_in_logs(juju, metrics_pattern)
+    grep_filters = ["juju_application=zookeeper", f"juju_model={juju.model}"]
+    result = await is_pattern_in_snap_logs(juju, grep_filters)
     assert result
 
 
 async def test_logs_are_scraped(juju: jubilant.Juju):
-    zookeeper_logs_pattern = r".+log.file.name=zookeeper.log.+log.file.path=/snap/opentelemetry-collector/\d+/shared-logs/zookeeper"
-    result = await is_pattern_in_logs(juju, zookeeper_logs_pattern)
+    grep_filters=[
+        "log.file.name=zookeeper.log",
+        "log.file.path=/snap/opentelemetry-collector"
+    ]
+    result = await is_pattern_in_snap_logs(juju, grep_filters)
     assert result
 
 
@@ -59,7 +50,6 @@ def test_alerts_are_aggregated(juju: jubilant.Juju):
         "otelcol/0",
         command="find /var/lib/juju/agents/unit-otelcol-0/charm/prometheus_alert_rules -type f",
     )
-    # pdb.set_trace()
     assert "zookeeper" in alert_files
 
 
@@ -69,5 +59,4 @@ def test_dashboards_are_aggregated(juju: jubilant.Juju):
         "otelcol/0",
         command="find /var/lib/juju/agents/unit-otelcol-0/charm/grafana_dashboards -type f",
     )
-    # pdb.set_trace()
     assert "zookeeper" in dashboard_files

--- a/tests/integration/test_principal.py
+++ b/tests/integration/test_principal.py
@@ -7,28 +7,11 @@ import pathlib
 import re
 
 import jubilant
-from tenacity import retry, stop_after_attempt, wait_fixed
+from helpers import is_pattern_in_snap_logs, is_pattern_not_in_logs
 
 # Juju is a strictly confined snap that cannot see /tmp, so we need to use something else
 TEMP_DIR = pathlib.Path(__file__).parent.resolve()
 
-
-# FIXME: Reduce retry count once fixed
-# https://github.com/canonical/opentelemetry-collector-operator/issues/32
-@retry(stop=stop_after_attempt(25), wait=wait_fixed(10))
-async def is_pattern_in_logs(juju: jubilant.Juju, pattern: str):
-    otelcol_logs = juju.ssh("otelcol/0", command="sudo snap logs opentelemetry-collector -n=all")
-    if not re.search(pattern, otelcol_logs):
-        raise Exception(f"Pattern {pattern} not found in the otelcol logs")
-    return True
-
-
-@retry(stop=stop_after_attempt(25), wait=wait_fixed(10))
-async def is_pattern_not_in_logs(juju: jubilant.Juju, pattern: str):
-    otelcol_logs = juju.ssh("otelcol/0", command="sudo snap logs opentelemetry-collector -n=all")
-    if re.search(pattern, otelcol_logs):
-        raise Exception(f"Pattern {pattern} found in the otelcol logs")
-    return True
 
 async def is_node_exporter_running_with_collectors(juju: jubilant.Juju, pattern: str):
     output_ps = juju.ssh("otelcol/0", command="ps ax | grep node-exporter | egrep -v 'grep|snapfuse'")
@@ -59,23 +42,25 @@ async def test_deploy(juju: jubilant.Juju, charm_22_04: str):
 
 
 async def test_var_log_is_scraped(juju: jubilant.Juju):
-    var_log_pattern = r".+log.file.path=/var/log"
-    is_var_log_scraped = await is_pattern_in_logs(juju, var_log_pattern)
+    var_log_pattern = ["log.file.path=/var/log"]
+    is_var_log_scraped = await is_pattern_in_snap_logs(juju, var_log_pattern)
     assert is_var_log_scraped
 
 
 async def test_path_exclude(juju: jubilant.Juju):
-    included_log_pattern = r".+log.file.name=cloud-init.log"
+    included_log_pattern = ["log.file.name=cloud-init.log"]
     excluded_log_pattern = r".+log.file.name=cloud-init-output.log"
-    is_included = await is_pattern_in_logs(juju, included_log_pattern)
+
+    is_included = await is_pattern_in_snap_logs(juju, included_log_pattern)
     assert is_included
-    is_excluded = await is_pattern_not_in_logs(juju, excluded_log_pattern)
+
+    is_excluded= is_pattern_not_in_logs(juju, excluded_log_pattern)
     assert is_excluded
 
 
 async def test_node_metrics(juju: jubilant.Juju):
-    node_metric = r"node_scrape_collector_success"
-    is_included = await is_pattern_in_logs(juju, node_metric)
+    node_metric = ["node_scrape_collector_success"]
+    is_included = await is_pattern_in_snap_logs(juju, node_metric)
     assert is_included
 
 async def test_node_exporter_collectors(juju: jubilant.Juju):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes #32 and https://github.com/canonical/opentelemetry-collector-snap/issues/30

## Solution
<!-- A summary of the solution addressing the above issue -->

We change the internal telemetry log level from `DEBUG` to `WARN` to avoid [infinite loop of logs](https://github.com/canonical/opentelemetry-collector-snap/issues/30#issuecomment-3140425299). Besides that, the scrape jobs for logs were split.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Just run integration tests.
