### PR TITLE
feat: add extra_alert_labels functionality to log alerts

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -498,6 +498,7 @@ class MyCharm(...):
 Do this, and all charm logs will be forwarded to Loki as soon as a relation is formed.
 """
 
+import copy
 import json
 import logging
 import os
@@ -1542,11 +1543,13 @@ class ConsumerBase(Object):
         skip_alert_topology_labeling: bool = False,
         *,
         forward_alert_rules: bool = True,
+        extra_alert_labels: Dict = {},
     ):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
         self._forward_alert_rules = forward_alert_rules
+        self._extra_alert_labels = extra_alert_labels
         self.topology = JujuTopology.from_charm(charm)
 
         try:
@@ -1562,6 +1565,15 @@ class ConsumerBase(Object):
 
         self._recursive = recursive
 
+    @staticmethod
+    def _inject_extra_labels_to_alert_rules(rules: Dict, extra_alert_labels: Dict) -> Dict:
+        """Return a copy of the rules dict with extra labels injected."""
+        result = copy.deepcopy(rules)
+        for group in result.get("groups", []):
+            for rule in group.get("rules", []):
+                rule.setdefault("labels", {}).update(extra_alert_labels)
+        return result
+
     def _handle_alert_rules(self, relation):
         if not self._charm.unit.is_leader():
             return
@@ -1572,6 +1584,11 @@ class ConsumerBase(Object):
         if self._forward_alert_rules:
             alert_rules.add_path(self._alert_rules_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
+
+        if self._extra_alert_labels:
+            alert_rules_as_dict = ConsumerBase._inject_extra_labels_to_alert_rules(
+                alert_rules_as_dict, self._extra_alert_labels
+            )
 
         relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
         relation.data[self._charm.app]["alert_rules"] = json.dumps(
@@ -1621,6 +1638,7 @@ class LokiPushApiConsumer(ConsumerBase):
         *,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         forward_alert_rules: bool = True,
+        extra_alert_labels: Dict = {},
     ):
         """Construct a Loki charm client.
 
@@ -1647,6 +1665,7 @@ class LokiPushApiConsumer(ConsumerBase):
             recursive: Whether to scan for rule files recursively.
             skip_alert_topology_labeling: whether to skip the alert topology labeling.
             forward_alert_rules: a boolean flag to toggle forwarding of charmed alert rules.
+            extra_alert_labels: Dict of extra labels to inject alert rules with.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set scrape job data (IP address and others)
 
@@ -1680,6 +1699,7 @@ class LokiPushApiConsumer(ConsumerBase):
             recursive,
             skip_alert_topology_labeling,
             forward_alert_rules=forward_alert_rules,
+            extra_alert_labels=extra_alert_labels,
         )
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_lifecycle_event)

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -127,6 +127,9 @@ def send_loki_logs(charm: CharmBase) -> List[Dict]:
         relation_name="send-loki-logs",
         alert_rules_path=LOKI_RULES_DEST_PATH,
         forward_alert_rules=forward_alert_rules,
+        extra_alert_labels=key_value_pair_string_to_dict(
+            cast(str, charm.model.config.get("extra_alert_labels", ""))
+        ),
     )
     charm.__setattr__("loki_consumer", loki_consumer)
     # TODO: Luca: probably don't need this anymore

--- a/tests/unit/test_extra_alert_labels.py
+++ b/tests/unit/test_extra_alert_labels.py
@@ -16,7 +16,7 @@ zinc_alerts = {
                     "name": "alertgroup",
                     "rules": [
                         {
-                            "alert": "missing",
+                            "alert": "Missing",
                             "expr": "up == 0",
                             "for": "0m",
                             "labels": {
@@ -66,7 +66,7 @@ def test_extra_alerts_config(ctx):
         for rule in group["rules"]:
             assert rule["labels"]["environment"] == "PRODUCTION"
             assert rule["labels"]["zone"] == "Mars"
-            if "opentelemetry_collector_k8s_alertgroup_alerts" in group["name"]:
+            if "opentelemetry_collector_alertgroup_alerts" in group["name"]:
                 assert rule["labels"]["juju_application"] == "zinc"
                 assert rule["labels"]["juju_charm"] == "zinc-k8s"
                 assert rule["labels"]["juju_model"] == "my_model"
@@ -89,9 +89,9 @@ def test_extra_alerts_config(ctx):
 
     for group in alert_rules_mod["groups"]:
         for rule in group["rules"]:
-            if "opentelemetry_collector_k8s_alertgroup_alerts" in group["name"]:
-                assert "environment" not in rule["labels"].keys()
-                assert "zone" not in rule["labels"].keys()
+            assert "environment" not in rule["labels"].keys()
+            assert "zone" not in rule["labels"].keys()
+            if "opentelemetry_collector_alertgroup_alerts" in group["name"]:
                 assert rule["labels"]["juju_application"] == "zinc"
                 assert rule["labels"]["juju_charm"] == "zinc-k8s"
                 assert rule["labels"]["juju_model"] == "my_model"
@@ -130,7 +130,7 @@ def test_extra_loki_alerts_config(ctx):
         for rule in group["rules"]:
             assert rule["labels"]["environment"] == "PRODUCTION"
             assert rule["labels"]["zone"] == "Mars"
-            if "opentelemetry_collector_k8s_alertgroup_alerts" in group["name"]:
+            if "opentelemetry_collector_alertgroup_alerts" in group["name"]:
                 assert rule["labels"]["juju_application"] == "zinc"
                 assert rule["labels"]["juju_charm"] == "zinc-k8s"
                 assert rule["labels"]["juju_model"] == "my_model"
@@ -153,9 +153,9 @@ def test_extra_loki_alerts_config(ctx):
 
     for group in alert_rules_mod["groups"]:
         for rule in group["rules"]:
-            if "opentelemetry_collector_k8s_alertgroup_alerts" in group["name"]:
-                assert "environment" not in rule["labels"].keys()
-                assert "zone" not in rule["labels"].keys()
+            assert "environment" not in rule["labels"].keys()
+            assert "zone" not in rule["labels"].keys()
+            if "opentelemetry_collector_alertgroup_alerts" in group["name"]:
                 assert rule["labels"]["juju_application"] == "zinc"
                 assert rule["labels"]["juju_charm"] == "zinc-k8s"
                 assert rule["labels"]["juju_model"] == "my_model"

--- a/tests/unit/test_extra_alert_labels.py
+++ b/tests/unit/test_extra_alert_labels.py
@@ -16,7 +16,7 @@ zinc_alerts = {
                     "name": "alertgroup",
                     "rules": [
                         {
-                            "alert": "Missing",
+                            "alert": "missing",
                             "expr": "up == 0",
                             "for": "0m",
                             "labels": {
@@ -85,6 +85,70 @@ def test_extra_alerts_config(ctx):
     out_2 = ctx.run(ctx.on.config_changed(), next_state)
     alert_rules_mod = json.loads(
         out_2.get_relation(remote_write_relation.id).local_app_data["alert_rules"]
+    )
+
+    for group in alert_rules_mod["groups"]:
+        for rule in group["rules"]:
+            if "opentelemetry_collector_k8s_alertgroup_alerts" in group["name"]:
+                assert "environment" not in rule["labels"].keys()
+                assert "zone" not in rule["labels"].keys()
+                assert rule["labels"]["juju_application"] == "zinc"
+                assert rule["labels"]["juju_charm"] == "zinc-k8s"
+                assert rule["labels"]["juju_model"] == "my_model"
+                assert rule["labels"]["juju_model_uuid"] == "74a5690b-89c9-44dd-984b-f69f26a6b751"
+
+
+def test_extra_loki_alerts_config(ctx):
+    # GIVEN a new key-value pair of extra alerts labels, for instance:
+    # juju config otelcol extra_alerts_labels="environment: PRODUCTION, zone=Mars"
+    config1: ConfigDict = {
+        "extra_alert_labels": "environment: PRODUCTION, zone=Mars",
+    }
+
+    # THEN The extra_alert_labels MUST be added to the alert rules.
+    receive_loki_logs_relation = Relation(
+        "receive-loki-logs", remote_app_name="zinc", remote_app_data=zinc_alerts
+    )
+    send_loki_logs_relation = Relation("send-loki-logs", remote_app_name="loki")
+    state = State(
+        leader=True,
+        relations=[
+            receive_loki_logs_relation,
+            send_loki_logs_relation,
+        ],
+        config=config1,  # type: ignore
+    )
+    out_0 = ctx.run(ctx.on.relation_changed(relation=receive_loki_logs_relation), state)
+    out_1 = ctx.run(
+        ctx.on.relation_joined(relation=out_0.get_relation(send_loki_logs_relation.id)), out_0
+    )
+    alert_rules = json.loads(
+        out_1.get_relation(send_loki_logs_relation.id).local_app_data["alert_rules"]
+    )
+
+    for group in alert_rules["groups"]:
+        for rule in group["rules"]:
+            assert rule["labels"]["environment"] == "PRODUCTION"
+            assert rule["labels"]["zone"] == "Mars"
+            if "opentelemetry_collector_k8s_alertgroup_alerts" in group["name"]:
+                assert rule["labels"]["juju_application"] == "zinc"
+                assert rule["labels"]["juju_charm"] == "zinc-k8s"
+                assert rule["labels"]["juju_model"] == "my_model"
+                assert rule["labels"]["juju_model_uuid"] == "74a5690b-89c9-44dd-984b-f69f26a6b751"
+
+    # GIVEN the config option for extra alert labels is unset
+    config2: ConfigDict = {"extra_alert_labels": ""}
+
+    # THEN the only labels present in the alert are the JujuTopology labels
+    next_state = State(
+        leader=True,
+        relations=out_1.relations,
+        containers=out_1.containers,
+        config=config2,
+    )
+    out_2 = ctx.run(ctx.on.config_changed(), next_state)
+    alert_rules_mod = json.loads(
+        out_2.get_relation(send_loki_logs_relation.id).local_app_data["alert_rules"]
     )
 
     for group in alert_rules_mod["groups"]:


### PR DESCRIPTION
Like #64 but for log alerts.

Relates to https://github.com/canonical/loki-k8s-operator/issues/529