### PR TITLE
chore: add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ juju deploy opentelemetry-collector
 
 ## Snap
 
-This charm, by default, uses the [Opentelemetry Collector snap](https://github.com/canonical/opentelemetry-collector-snap/).
+This charm uses the [Opentelemetry Collector snap](https://github.com/canonical/opentelemetry-collector-snap/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# opentelemetry-collector-operator
+# OpenTelemetry Collector Operator for Machines
+
+[![CharmHub Badge](https://charmhub.io/opentelemetry-collector/badge.svg)](https://charmhub.io/opentelemetry-collector)
+[![Release](https://github.com/canonical/opentelemetry-collector-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/opentelemetry-collector-k8s-operator/actions/workflows/release.yaml)
+[![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
+
+This repository contains the source code for a Charmed Operator that drives [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector), a vendor-agnostic way to receive, process and export telemetry data, on machines (LXD, MAAS, etc).
+
+## Usage
+
+Assuming you have access to a bootstrapped Juju controller, you can:
+
+```bash
+$ juju deploy opentelemetry-collector
+```
+
+## Snap
+
+This charm, by default, uses the [Opentelemetry Collector snap](https://github.com/canonical/opentelemetry-collector-snap/).
+
+## Contributing
+
+Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and the [contributing](https://github.com/canonical/opentelemetry-collector-k8s-operator/blob/main/CONTRIBUTING.md) doc for developer guidance.


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The machine charm for Opentelemetry Collector Operator has no README, unlike the K8s charm.

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR adds a README to this repo which is similar to the [K8s README](https://github.com/canonical/opentelemetry-collector-k8s-operator/blob/main/README.md) but with the necessary changes.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of the charm, ... -->
