### PR TITLE
fix: use platform.machine() to determine arch

### DIFF
--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -21,7 +21,7 @@ def get_system_arch() -> str:
     If platform is x86_64 or amd64, it returns amd64.
     If platform is aarch64, arm64, armv8b, or armv8l, it returns arm64.
     """
-    arch = platform.processor()
+    arch = platform.machine()
     if arch in ["x86_64", "amd64"]:
         arch = "amd64"
     elif arch in ["aarch64", "arm64", "armv8b", "armv8l"]:


### PR DESCRIPTION
As reported by @michaeldmitry , `platform.processor()` can sometimes return an empty string (it happend in a Pi environment). `platform.machine()` seems to be a better alternative.

Some extra info from the Python docs:
[platform.machine](https://docs.python.org/3/library/platform.html#platform.machine)
> platform.machine()[¶](https://docs.python.org/3/library/platform.html#platform.machine)
Returns the machine type, e.g. 'AMD64'. An empty string is returned if the value cannot be determined.
> The output is platform-dependent and may differ in casing and naming conventions.

[platform.processor](https://docs.python.org/3/library/platform.html#platform.processor)
> Returns the (real) processor name, e.g. 'amdk6'.
> An empty string is returned if the value cannot be determined. Note that many platforms do not provide this information or simply return the same value as for [machine()](https://docs.python.org/3/library/platform.html#platform.machine). NetBSD does this.