### PR TITLE
chore: pin TF Juju provider to version = "< 1.0.0"

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,37 +3,41 @@
 
 This is a Terraform module facilitating the deployment of opentelemetry-collector charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
-
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
-This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
-## API
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | < 1.0.0 |
 
-### Inputs
-The module offers the following configurable inputs:
+## Providers
 
-| Name | Type | Description | Required |
-| - | - | - | - |
-| `app_name`| string | Application name | opentelemetry-collector |
-| `channel`| string | Channel that the charm is deployed from |  |
-| `config`| map(string) | Map of the charm configuration options | {} |
-| `constraints`| string | Constraints for the Juju deployment| arch=amd64 |
-| `model`| string | Name of the model that the charm is deployed on |  |
-| `revision`| number | Revision number of the charm name | null |
-| `storage_directives`| map(string) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | {} |
-| `units`| number | Number of units to deploy | 1 |
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | < 1.0.0 |
 
-### Outputs
-Upon applied, the module exports the following outputs:
+## Modules
+
+No modules.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"opentelemetry-collector"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
+| <a name="input_model"></a> [model](#input\_model) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
 
 | Name | Description |
-| - | - |
-| `app_name`|  Application name |
-| `provides`|  Map of `provides` endpoints |
-| `requires`|  Map of `requires` endpoints |
-
-## Usage
-
-Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
-
-To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.15.0"
+      version = "< 1.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR pins the TF provider for the root module and submodules to `version = "< 1.0.0"` so that we can tag this repo for users to always be able to source our modules for TF Juju provider `< v1`. See [this tracking issue](https://github.com/canonical/observability-stack/issues/135) for details.