### PR TITLE
chore: implement new prometheus remote write requirements

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -228,6 +228,7 @@ def send_remote_write(charm: CharmBase) -> List[Dict[str, str]]:
         extra_alert_labels=key_value_pair_string_to_dict(
             cast(str, charm.model.config.get("extra_alert_labels", ""))
         ),
+        peer_relation_name="peers",
     )
     charm.__setattr__("remote_write", remote_write)
     # TODO: add alerts from remote write

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
@@ -347,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.3.2"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
@@ -356,9 +356,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/b3/bd83f017c73044a221bc0c7ad62f583d11d1276190f65eb1c086150e24e4/cosl-1.3.2.tar.gz", hash = "sha256:dea8e937629b44232bb306f76fbf88064a1a0093fe66dacdd43ab2cb06b7f35f", size = 46029, upload-time = "2025-11-20T22:03:14.031Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/c41b6308ce2a6a1523fe1d5cebb831ad779e55008f8d8c0c724fccc4b407/cosl-1.4.0.tar.gz", hash = "sha256:eb6ebf682f76eec24e3c9759fb6fe5185660fcf7bb3dd8adc42e5a74816c8615", size = 46191, upload-time = "2025-11-25T17:16:01.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/e2/d10330cce5be3d8842d3a8889ed368546a2fa41b701c1abb56b0bf9b59f2/cosl-1.3.2-py3-none-any.whl", hash = "sha256:52ca0983fb0bf3bfa8d0bb796fc6a8208a71bbf4481a5c90905b1f71a1184d4b", size = 36598, upload-time = "2025-11-20T22:03:12.736Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9b/716ceb6021530b9cdbbfd681b7f296b660cdc763c365283e82581a71c299/cosl-1.4.0-py3-none-any.whl", hash = "sha256:410042805b17876c19d405ff5bf5c2461a84a7bff389ce3ad928f44e8c09b882", size = 36649, upload-time = "2025-11-25T17:16:00.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Tracking issue with further context: https://github.com/canonical/cos-lib/issues/167

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Bumps `cosl` so new generic alert rules (with new descriptions) are used.
2. Fetches charm libs so new changes from Prometheus remote write lib are present (lib patch 11).
3. Passes the name of this charm's peer relation when instantiating `PromtheusRemoteWriteConsumer`.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Pack this charm and relate it to Ubuntu and Prometheus.
2. Scale up Ubuntu to 2.
3. On the Prometheus alerts page, you should now see 2 HostMetricsMissing alerts for Otelcol, one per each unit.
<img width="2518" height="314" alt="image" src="https://github.com/user-attachments/assets/f0ec0d11-2a96-4b12-84dd-d6e135d6339e" />

4. If you `sudo snap stop opentelemetry-collector` in one of the two LXD machines, one of the two HostMetricsMissing alerts should be triggered AND the AggregatorMetricsMissing alert should NOT be triggered.
<img width="2547" height="296" alt="image" src="https://github.com/user-attachments/assets/34045bee-7fdc-4ee8-bd78-b2b630d13c27" />

5. And if you stop the snap in both LXD machines, both alerts will be triggered and since ALL units are down, the AggregatorMetricsMissing alert now should fire too.

<img width="2532" height="301" alt="image" src="https://github.com/user-attachments/assets/b2859b5f-e180-4d06-9917-caf28a6b0d81" />

The severity of the HostMetricsMissing alerts must be critical since Otelcol machine is a subordinate charm.
<img width="2532" height="664" alt="image" src="https://github.com/user-attachments/assets/b17de052-dd15-4f4e-bc5c-541f9b05ff21" />

## Upgrade Notes
<!-- To upgrade from an older revision of the charm, ... -->
