### PR TITLE
ops pre-release test: use ops==3.4.0b3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.0"
 requires-python = ">=3.10"
 
 dependencies = [
-  "ops[tracing]>=3.1",
+  "ops[tracing]==3.4.0b3",
   "pyyaml",
   "urllib3",
   "jsonschema",


### PR DESCRIPTION
This PR is not for merging, it's just for running CI with the upcoming ops v3.4.0.