### PR TITLE
fix: TLS certificates integration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -32,6 +32,7 @@ from constants import (
     NODE_EXPORTER_ENABLED_COLLECTORS,
     RECV_CA_CERT_FOLDER_PATH,
     SERVER_CERT_PATH,
+    SERVER_CA_CERT_PATH,
     SERVER_CERT_PRIVATE_KEY_PATH,
 )
 from singleton_snap import SingletonSnapManager, SnapRegistrationFile
@@ -159,13 +160,17 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         receive_ca_certs_hash = integrations.receive_ca_cert(
             self,
             recv_ca_cert_folder_path=LocalPath(RECV_CA_CERT_FOLDER_PATH),
-            refresh_certs=refresh_certs,
         )
         server_cert_hash = integrations.receive_server_cert(
             self,
             server_cert_path=LocalPath(SERVER_CERT_PATH),
             private_key_path=LocalPath(SERVER_CERT_PRIVATE_KEY_PATH),
+            root_ca_cert_path=LocalPath(SERVER_CA_CERT_PATH),
         )
+        # Refresh system certs
+        # This must be run after receive_ca_cert and/or receive_server_cert because they update
+        # certs in the /usr/local/share/ca-certificates directory
+        refresh_certs()
 
         # Global scrape configs
         global_configs = {

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,10 +3,9 @@
 from typing import Final, Set
 
 RECV_CA_CERT_FOLDER_PATH: Final[str] = "/usr/local/share/ca-certificates/juju_receive-ca-cert"
-SERVER_CERT_PATH: Final[str] = (
-    "/var/snap/opentelemetry-collector/common/juju_tls-certificates/otelcol-server.crt"
-)
-SERVER_CERT_PRIVATE_KEY_PATH: Final[str] = "/var/snap/opentelemetry-collector/common/private.key"
+SERVER_CERT_PATH: Final[str] = "/var/snap/opentelemetry-collector/common/otelcol-server-cert.crt"
+SERVER_CERT_PRIVATE_KEY_PATH: Final[str] = "/var/snap/opentelemetry-collector/common/otelcol-private-key.key"
+SERVER_CA_CERT_PATH: Final[str] = "/usr/local/share/ca-certificates/juju_receive-ca-cert/cos-ca.crt"
 CONFIG_FOLDER: Final[str] = "/etc/otelcol/config.d"
 SERVICE_NAME: Final[str] = "otelcol"
 METRICS_RULES_SRC_PATH: Final[str] = "src/prometheus_alert_rules"

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -9,7 +9,7 @@ import socket
 from collections import namedtuple
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, cast, get_args
+from typing import Any, Dict, List, Optional, Set, cast, get_args
 
 import yaml
 from charmlibs.pathops import PathProtocol
@@ -297,7 +297,8 @@ def receive_traces(charm: CharmBase, tls: bool) -> Set:
         )
     return requested_tracing_protocols
 
-def receive_profiles(charm: CharmBase, tls:bool) -> None:
+
+def receive_profiles(charm: CharmBase, tls: bool) -> None:
     """Integrate with other charms over the receive-profiles relation endpoint."""
     if not charm.unit.is_leader():
         # TODO: leader-only because of
@@ -307,12 +308,8 @@ def receive_profiles(charm: CharmBase, tls:bool) -> None:
     grpc_endpoint = f"{fqdn}:{Port.otlp_grpc.value}"
     # this charm lib exposes a holistic API, so we don't need to bind the instance
     ProfilingEndpointProvider(
-        charm.model.relations['receive-profiles'],
-        app=charm.app
-        ).publish_endpoint(
-        otlp_grpc_endpoint=grpc_endpoint,
-        insecure=not tls
-    )
+        charm.model.relations["receive-profiles"], app=charm.app
+    ).publish_endpoint(otlp_grpc_endpoint=grpc_endpoint, insecure=not tls)
 
 
 def send_profiles(charm: CharmBase) -> List[ProfilingEndpoint]:
@@ -321,8 +318,10 @@ def send_profiles(charm: CharmBase) -> List[ProfilingEndpoint]:
     Returns:
         All profiling endpoints that we are receiving over `profiling` integrations.
     """
-    profiling_requirer = ProfilingEndpointRequirer(charm.model.relations['send-profiles'])
-    return [ProfilingEndpoint(ep.otlp_grpc, ep.insecure) for ep in profiling_requirer.get_endpoints()]
+    profiling_requirer = ProfilingEndpointRequirer(charm.model.relations["send-profiles"])
+    return [
+        ProfilingEndpoint(ep.otlp_grpc, ep.insecure) for ep in profiling_requirer.get_endpoints()
+    ]
 
 
 def send_traces(charm: CharmBase) -> Optional[str]:
@@ -482,11 +481,12 @@ def receive_server_cert(
     charm: CharmBase,
     server_cert_path: PathProtocol,
     private_key_path: PathProtocol,
+    root_ca_cert_path: PathProtocol,
 ) -> str:
-    """Integrate to receive a certificate and private key for the charm from relation data.
+    """Integrate to receive private key, cert, CA cert for the charm from relation data.
 
-    The certificate and key are obtained via the tls_certificates(v4) library,
-    and pushed to the workload container.
+    The key and certs are obtained via the tls_certificates(v4) library, and pushed to the
+    workload container.
 
     Returns:
         Hash of server cert and private key, to be used as reload trigger if it changed.
@@ -521,26 +521,26 @@ def receive_server_cert(
 
         server_cert_path.unlink() if server_cert_path.exists() else None
         private_key_path.unlink() if private_key_path.exists() else None
+        root_ca_cert_path.unlink() if root_ca_cert_path.exists() else None
         return sha256("")
 
     # Push the certificate and key to disk
     server_cert_path.parent.mkdir(parents=True, exist_ok=True)
-    server_cert_path.write_text(str(provider_certificate.certificate))
+    server_cert_path.write_text(str(provider_certificate.certificate.raw))
     private_key_path.parent.mkdir(parents=True, exist_ok=True)
     private_key_path.write_text(str(private_key))
+    root_ca_cert_path.parent.mkdir(parents=True, exist_ok=True)
+    root_ca_cert_path.write_text(str(provider_certificate.ca.raw))
 
-    logger.info("Certificate and private key have been pushed to disk")
+    logger.info("Certificates and private key have been pushed to disk")
+
+    # NOTE: we run `update-ca-certificates` in charm code
 
     return sha256(str(provider_certificate.certificate) + str(private_key))
 
 
-def receive_ca_cert(
-    charm: CharmBase, recv_ca_cert_folder_path: PathProtocol, refresh_certs: Callable
-) -> str:
+def receive_ca_cert(charm: CharmBase, recv_ca_cert_folder_path: PathProtocol) -> str:
     """Reconcile the certificates from the `receive-ca-cert` relation.
-
-    This function saves the certificates to disk, and runs
-    `update-ca-certificates` to trust them.
 
     Returns:
         Hash of the certificates to trust, to be used as reload trigger when changed.
@@ -562,8 +562,7 @@ def receive_ca_cert(
             cert_path = recv_ca_cert_folder_path.joinpath(f"{i}.crt")
             cert_path.write_text(cert)
 
-    # Refresh system certs
-    refresh_certs()
+    # NOTE: we run `update-ca-certificates` in charm code
 
     # A hot-reload doesn't pick up new system certs - need to restart the service
     return sha256(yaml.safe_dump(ca_certs))

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Feature: COS Agent integration works as expected."""
+"""Feature: Ingested traces are pushed to Tempo via COS Agent."""
 
 import pathlib
 import jubilant

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,17 +1,24 @@
+from dataclasses import dataclass
 from pathlib import Path
 from shutil import copytree
 from unittest.mock import MagicMock, patch
 
 import pytest
+from charms.tls_certificates_interface.v4.tls_certificates import (
+    Certificate,
+    TLSCertificatesRequiresV4,
+)
 from ops.testing import Context
 
 from charm import OpenTelemetryCollectorCharm
 
-CHARM_ROOT=Path(__file__).parent.parent.parent
+CHARM_ROOT = Path(__file__).parent.parent.parent
+
 
 @pytest.fixture
 def unit_id():
     return 0
+
 
 @pytest.fixture
 def app_name():
@@ -29,16 +36,23 @@ def ctx(tmp_path, unit_id, app_name):
     # Create a virtual charm_root so Scenario respects the `src_dirs`
     # Related to https://github.com/canonical/operator/issues/1673
     for src_dir in src_dirs:
-        source_path = CHARM_ROOT/ "src" / src_dir
+        source_path = CHARM_ROOT / "src" / src_dir
         target_path = tmp_path / "src" / src_dir
         copytree(source_path, target_path, dirs_exist_ok=True)
     with patch("charm.refresh_certs", lambda: True):
-        yield Context(OpenTelemetryCollectorCharm, charm_root=tmp_path, unit_id=unit_id, app_name=app_name)
+        yield Context(
+            OpenTelemetryCollectorCharm, charm_root=tmp_path, unit_id=unit_id, app_name=app_name
+        )
 
 
 @pytest.fixture
-def cert():
-    return "mocked_certificate"
+def server_cert():
+    return "mocked_server_certificate"
+
+
+@pytest.fixture
+def ca_cert():
+    return "mocked_ca_certificate"
 
 
 @pytest.fixture
@@ -46,14 +60,30 @@ def private_key():
     return "mocked_private_key"
 
 
+@dataclass
+class Cert:
+    raw: str
+
+
 class MockCertificate:
-    def __init__(self, certificate):
-        self.certificate = certificate
+    def __init__(self, server_cert, ca_cert):
+        self.certificate = Cert(server_cert)
+        self.ca = Cert(ca_cert)
+
+
+@pytest.fixture(autouse=True)
+def cert_obj(server_cert, ca_cert):
+    return MockCertificate(server_cert, ca_cert)
 
 
 @pytest.fixture
-def cert_obj(cert):
-    return MockCertificate(cert)
+def tls_mock(cert_obj, private_key):
+    with patch.object(
+        TLSCertificatesRequiresV4, "_find_available_certificates", return_value=None
+    ), patch.object(
+        TLSCertificatesRequiresV4, "get_assigned_certificate", return_value=(cert_obj, private_key)
+    ), patch.object(Certificate, "from_string", return_value=cert_obj):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -63,7 +93,9 @@ def juju_hook_name(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.fixture(autouse=True)
 def otelcol_version():
-    with patch.object(OpenTelemetryCollectorCharm, "_otelcol_version", property(lambda *_: "0.0.0")):
+    with patch.object(
+        OpenTelemetryCollectorCharm, "_otelcol_version", property(lambda *_: "0.0.0")
+    ):
         yield OpenTelemetryCollectorCharm
 
 
@@ -90,10 +122,11 @@ def recv_ca_folder_path(tmp_path):
 
 @pytest.fixture
 def server_cert_paths(tmp_path):
-    """Mock the received CA certificates directory path and ensure it exists."""
+    """Mock the received certificate directories paths and ensure they exists."""
     with patch("charm.SERVER_CERT_PATH", tmp_path / "juju_server-cert") as server_cert:
-        with patch("charm.SERVER_CERT_PRIVATE_KEY_PATH", tmp_path/"juju_privkey") as privkey:
-            yield server_cert, privkey
+        with patch("charm.SERVER_CERT_PRIVATE_KEY_PATH", tmp_path / "juju_privkey") as privkey:
+            with patch("charm.SERVER_CA_CERT_PATH", tmp_path / "juju_ca-cert") as ca_cert:
+                yield server_cert, privkey, ca_cert
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -9,9 +9,16 @@ from charmlibs.pathops import LocalPath
 from singleton_snap import SnapRegistrationFile
 
 
-def get_otelcol_file(unit_name: str, config_folder:str) -> dict:
+def get_otelcol_config_file(unit_name: str, config_folder:str) -> dict:
     config_filename = f"{SnapRegistrationFile._normalize_name(unit_name)}.yaml"
     config_path = LocalPath(Path(config_folder)/config_filename)
+    assert config_path.exists(), "file does not exist"
+    cfg = yaml.safe_load(config_path.read_text())
+    return cfg
+
+
+def get_otelcol_file(file:str) -> dict:
+    config_path = LocalPath(Path(file))
     assert config_path.exists(), "file does not exist"
     cfg = yaml.safe_load(config_path.read_text())
     return cfg

--- a/tests/unit/test_profiling_integration.py
+++ b/tests/unit/test_profiling_integration.py
@@ -4,21 +4,8 @@ from unittest.mock import patch
 import pytest
 from ops.testing import Relation, State
 
-from charms.tls_certificates_interface.v4.tls_certificates import (
-    TLSCertificatesRequiresV4,
-    Certificate,
-)
-from tests.unit.helpers import get_otelcol_file
+from tests.unit.helpers import get_otelcol_config_file
 
-
-@pytest.fixture
-def tls_mock(cert_obj, private_key):
-    with patch.object(
-        TLSCertificatesRequiresV4, "_find_available_certificates", return_value=None
-    ), patch.object(
-        TLSCertificatesRequiresV4, "get_assigned_certificate", return_value=(cert_obj, private_key)
-    ), patch.object(Certificate, "from_string", return_value=cert_obj):
-        yield
 
 def test_profiling_pipeline_disabled_by_default(ctx, unit_name, config_folder):
     """Scenario: we don't have a profiling relation."""
@@ -27,9 +14,9 @@ def test_profiling_pipeline_disabled_by_default(ctx, unit_name, config_folder):
     ctx.run(ctx.on.update_status(), state=state_in)
 
     # THEN the there is no `profiling` pipeline
-    cfg = get_otelcol_file(unit_name, config_folder)
-    assert 'profiles' not in cfg['service']['pipelines']
-    assert not any('profiling' in exporter_name for exporter_name in cfg['exporters'])
+    cfg = get_otelcol_config_file(unit_name, config_folder)
+    assert "profiles" not in cfg["service"]["pipelines"]
+    assert not any("profiling" in exporter_name for exporter_name in cfg["exporters"])
 
 
 @pytest.mark.parametrize("insecure_skip_verify", (True, False))
@@ -45,17 +32,18 @@ def test_send_profiles_integration(ctx, insecure_skip_verify, insecure, unit_nam
         remote_app_data={
             "otlp_grpc_endpoint_url": json.dumps(pyro_url),
             "insecure": json.dumps(insecure),
-        }
+        },
     )
-    state_in = State(relations=[send_profiles],
-                     config={"tls_insecure_skip_verify": insecure_skip_verify})
+    state_in = State(
+        relations=[send_profiles], config={"tls_insecure_skip_verify": insecure_skip_verify}
+    )
     ctx.run(ctx.on.update_status(), state=state_in)
 
     # THEN the profiling pipeline contains an exporter to the expected url
-    cfg = get_otelcol_file(unit_name, config_folder)
-    assert cfg['service']['pipelines']['profiles']['exporters'][0] == 'otlp/profiling/0'
-    assert cfg['service']['pipelines']['profiles']['receivers'][0] == "otlp"
-    assert cfg['exporters']['otlp/profiling/0']['endpoint'] == pyro_url
+    cfg = get_otelcol_config_file(unit_name, config_folder)
+    assert cfg["service"]["pipelines"]["profiles"]["exporters"][0] == "otlp/profiling/0"
+    assert cfg["service"]["pipelines"]["profiles"]["receivers"][0] == "otlp"
+    assert cfg["exporters"]["otlp/profiling/0"]["endpoint"] == pyro_url
     tls_config = cfg["exporters"]["otlp/profiling/0"]["tls"]
     assert tls_config["insecure"] is insecure
     assert tls_config["insecure_skip_verify"] == insecure_skip_verify
@@ -63,25 +51,27 @@ def test_send_profiles_integration(ctx, insecure_skip_verify, insecure, unit_nam
 
 @patch("socket.getfqdn", return_value="localhost")
 @pytest.mark.parametrize("insecure_skip_verify", (True, False))
-def test_receive_profiles_integration(sock_mock, ctx, insecure_skip_verify, unit_name, config_folder):
+def test_receive_profiles_integration(
+    sock_mock, ctx, insecure_skip_verify, unit_name, config_folder
+):
     """Scenario: a receive-profiles relation joined."""
     # GIVEN otelcol deployed in isolation
     # WHEN a receive-profiles relation joins and pyroscope sent an endpoint
-    receive_profiles = Relation(
-        endpoint="receive-profiles"
+    receive_profiles = Relation(endpoint="receive-profiles")
+    state_in = State(
+        relations=[receive_profiles],
+        config={"tls_insecure_skip_verify": insecure_skip_verify},
+        leader=True,
     )
-    state_in = State(relations=[receive_profiles],
-                     config={"tls_insecure_skip_verify": insecure_skip_verify},
-                     leader=True)
     state_out = ctx.run(ctx.on.update_status(), state=state_in)
 
     # THEN the profiling pipeline contains a profiling pipeline, but no exporters other than debug
-    cfg = get_otelcol_file(unit_name,config_folder)
-    assert cfg['service']['pipelines']['profiles']['exporters'] == ['debug/otelcol/0']
+    cfg = get_otelcol_config_file(unit_name, config_folder)
+    assert cfg["service"]["pipelines"]["profiles"]["exporters"] == ["debug/otelcol/0"]
 
     # AND we publish to app databag our profile ingestion endpoints for otlp_http and otlp_grpc
     receive_profiles_app_data = state_out.get_relation(receive_profiles.id).local_app_data
-    assert receive_profiles_app_data['otlp_grpc_endpoint_url']
+    assert receive_profiles_app_data["otlp_grpc_endpoint_url"]
 
 
 @pytest.mark.parametrize("insecure_skip_verify", (True, False))
@@ -99,7 +89,7 @@ def test_profiling_integration_tls(ctx, unit_name, insecure, config_folder, inse
     cert2b = "-----BEGIN CERTIFICATE-----\n ... cert2b ... \n-----END CERTIFICATE-----"
     server_cert_rel = Relation(
         endpoint="receive-server-cert",
-        remote_app_data={"certificates": json.dumps([cert1a, cert1b])}
+        remote_app_data={"certificates": json.dumps([cert1a, cert1b])},
     )
     ca_cert_rel = Relation(
         "receive-ca-cert", remote_app_data={"certificates": json.dumps([cert2a, cert2b])}
@@ -112,18 +102,20 @@ def test_profiling_integration_tls(ctx, unit_name, insecure, config_folder, inse
         remote_app_data={
             "otlp_grpc_endpoint_url": json.dumps(pyro_url),
             "insecure": json.dumps(insecure),
-        }
+        },
     )
-    state_in = State(relations=[profiling, server_cert_rel, ca_cert_rel],
-                     config={"tls_insecure_skip_verify": insecure_skip_verify})
+    state_in = State(
+        relations=[profiling, server_cert_rel, ca_cert_rel],
+        config={"tls_insecure_skip_verify": insecure_skip_verify},
+    )
 
     with patch("charm.refresh_certs", lambda: True):
         ctx.run(ctx.on.update_status(), state=state_in)
 
     # THEN  the profiling pipeline contains an exporter to the expected url
-    cfg = get_otelcol_file(unit_name, config_folder)
-    assert cfg['service']['pipelines']['profiles']['exporters'][0] == 'otlp/profiling/0'
-    assert cfg['exporters']['otlp/profiling/0']['endpoint'] == pyro_url
+    cfg = get_otelcol_config_file(unit_name, config_folder)
+    assert cfg["service"]["pipelines"]["profiles"]["exporters"][0] == "otlp/profiling/0"
+    assert cfg["exporters"]["otlp/profiling/0"]["endpoint"] == pyro_url
     tls_config = cfg["exporters"]["otlp/profiling/0"]["tls"]
     assert tls_config["insecure"] is insecure
     assert tls_config["insecure_skip_verify"] == insecure_skip_verify

--- a/tests/unit/test_tls_certificates.py
+++ b/tests/unit/test_tls_certificates.py
@@ -1,0 +1,131 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Feature: Otelcol server can run in HTTPS mode."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from charms.tls_certificates_interface.v4.tls_certificates import (
+    Certificate,
+    TLSCertificatesRequiresV4,
+)
+from helpers import get_otelcol_config_file, get_otelcol_file
+from ops.testing import Relation, State
+
+from constants import (
+    SERVER_CA_CERT_PATH,
+    SERVER_CERT_PATH,
+    SERVER_CERT_PRIVATE_KEY_PATH,
+)
+
+
+def no_certs_in_receivers(otelcol_config: dict):
+    return not any(
+        ("key_file" in protocol.get("tls", {}) or "cert_file" in protocol.get("tls", {}))
+        for receiver in otelcol_config["receivers"].values()
+        for protocol in receiver.get("protocols", {}).values()
+    )
+
+
+def test_no_tls_certificates_relation(ctx, unit_name, config_folder):
+    """Scenario: Otelcol deployed without tls-certificates relation."""
+    # GIVEN otelcol deployed in isolation
+    ctx.run(ctx.on.update_status(), State())
+    # THEN the config file doesn't include "key_file" nor "cert_file"
+    assert no_certs_in_receivers(get_otelcol_config_file(unit_name, config_folder))
+    # AND WHEN telemetry sources (e.g. flog) join to create a receiver
+    data_source = Relation(
+        endpoint="receive-loki-logs",
+        interface="loki_push_api",
+    )
+    state_in = State(relations=[data_source])
+    ctx.run(ctx.on.update_status(), state_in)
+    # THEN receivers in the config file don't include "key_file" nor "cert_file"
+    assert no_certs_in_receivers(get_otelcol_config_file(unit_name, config_folder))
+
+
+def test_waiting_for_cert(ctx):
+    """Scenario: a tls-certificates relation joined, but we didn't get the cert yet."""
+    # GIVEN otelcol deployed in isolation
+    # WHEN a tls-certificates relation joins but the CA didn't reply with a cert yet
+    ssc = Relation(
+        endpoint="receive-server-cert",
+        interface="tls-certificate",
+    )
+    state_in = State(relations=[ssc])
+    state_out = ctx.run(ctx.on.update_status(), state=state_in)
+    # THEN the charm is in waiting state
+    assert state_out.unit_status.name == "waiting"
+    assert "waiting for a cert" in state_out.unit_status.message
+
+
+def test_transitioned_from_http_to_https_to_http(
+    ctx, unit_name, cert_obj, private_key, server_cert, ca_cert, config_folder, server_cert_paths
+):
+    """Scenario: a tls-certificates relation joins and is later removed."""
+    # GIVEN otelcol has received a cert
+    ssc = Relation(
+        endpoint="receive-server-cert",
+        interface="tls-certificate",
+    )
+    data_sink = Relation(
+        endpoint="send-loki-logs",
+        interface="loki_push_api",
+        remote_units_data={
+            0: {"endpoint": '{"url": "http://fqdn-0:3100/loki/api/v1/push"}'},
+        },
+    )
+    state_in = State(relations=[ssc, data_sink])
+    # Note: We patch the cert creation process on disk since it requires a dynamic cert, CSR, CA,
+    # and cert chain in the remote app databag
+    with patch.object(
+        TLSCertificatesRequiresV4, "_find_available_certificates", return_value=None
+    ), patch.object(
+        TLSCertificatesRequiresV4, "get_assigned_certificate", return_value=(cert_obj, private_key)
+    ), patch.object(Certificate, "from_string", return_value=cert_obj):
+        ctx.run(ctx.on.update_status(), state=state_in)
+    # THEN the cert and private key files were written to disk
+    assert server_cert == get_otelcol_file(server_cert_paths[0])
+    assert private_key == get_otelcol_file(server_cert_paths[1])
+    assert ca_cert == get_otelcol_file(server_cert_paths[2])
+    otelcol_config = get_otelcol_config_file(unit_name, config_folder)
+    # AND config file includes "key_file" and "cert_file" for receivers with a "protocols" section
+    protocols = otelcol_config["receivers"]["otlp"]["protocols"]
+    for protocol in protocols:
+        assert protocols[protocol]["tls"]["cert_file"] == SERVER_CERT_PATH
+        assert protocols[protocol]["tls"]["key_file"] == SERVER_CERT_PRIVATE_KEY_PATH
+    # WHEN the tls-certificates relation is removed
+    state_in = State(relations=[data_sink])
+    ctx.run(ctx.on.update_status(), state=state_in)
+    # THEN the config file doesn't include "key_file" nor "cert_file" for all receivers
+    otelcol_config = get_otelcol_config_file(unit_name, config_folder)
+    assert no_certs_in_receivers(otelcol_config)
+    # AND the cert and private key files are not on disk
+    with pytest.raises(AssertionError, match="file does not exist"):
+        get_otelcol_file(SERVER_CERT_PATH)
+    with pytest.raises(AssertionError, match="file does not exist"):
+        get_otelcol_file(SERVER_CA_CERT_PATH)
+    with pytest.raises(AssertionError, match="file does not exist"):
+        get_otelcol_file(SERVER_CERT_PRIVATE_KEY_PATH)
+
+@pytest.mark.skip(reason="https://github.com/canonical/operator/issues/1858")
+def test_https_endpoint_is_provided(ctx, cert_obj, private_key):
+    """Scenario: Otelcol provides other charms its TLS endpoint."""
+    # GIVEN otelcol is in TLS mode
+    ssc = Relation(
+        endpoint="receive-server-cert",
+        interface="tls-certificate",
+    )
+    data_source = Relation(
+        endpoint="receive-loki-logs",
+        interface="loki_push_api",
+    )
+    state_in = State(relations=[ssc, data_source])
+    # WHEN a relation_changed event on the "receive-loki-logs" endpoint fires
+    state_out = ctx.run(ctx.on.relation_changed(data_source), state=state_in)
+    # THEN Otelcol provides its TLS endpoint in the databag
+    for relation in state_out.relations:
+        if relation.endpoint == "receive-loki-logs":
+            assert "https" in json.loads(relation.local_unit_data["endpoint"])["url"]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Same as this PR, but for VM charm:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/149

## Solution
<!-- A summary of the solution addressing the above issue -->
I had to add the `tls-certificates.py` (which existed in the k8s charm) unit test to ensure this works.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e unit -- tests/unit/test_tls_certificates.py`
Otherwise, see the linked PR and the linked issue which explains manual testing steps.
