### PR TITLE
Add observability issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/observability_issue.yml
+++ b/.github/ISSUE_TEMPLATE/observability_issue.yml
@@ -42,7 +42,7 @@ body:
         Please indicate what signal/alert you expected to see and under what conditions
         (metric, log pattern, trace span, threshold, duration),
         why/how an alert should have fired sooner,
-        Specific metrics / labels missing (e.g. per-endpoint latency, per-replica memory usage),
+        specific metrics / labels missing (e.g. per-endpoint latency, per-replica memory usage),
         log fields missing or unstructured, missing span attributes, missing dashboards / alert rules, etc.
         Do you have a fix suggestion?
     validations:
@@ -63,7 +63,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: >
+      description: |
         We need to know a bit more about the context in which you run into the problem.
         - What kind of an environment is it.
         - What channel and revision you deployed the affected charm(s) from (e.g. rev123 from `latest/edge`).


### PR DESCRIPTION
This template helps users report observability issues by providing structured fields for expected behavior, actual behavior, relevant telemetry, and reproduction steps.

## Issue
Since alert rules and dashboards are organic to charms, observability-related issues are reported in the charm repo.
We are currently missing a template dedicated to observability issues, so reporters sometimes miss key information, only because the reporter was not prompted to provide it.


## Solution
Add a new issue template, prompting the reporter to provide info to help resolve the issue quickly.
The idea is to collect feedback from stakeholder about this new template, and then propose to other charm maintainers to include it in their repo.

A secondary goal is to have a template that would prompt issue filers to provide sufficient context and direction so that AI agents could be most useful. 

## Context
Example for an observability-related issue created after root causing:
- https://github.com/canonical/postgresql-operator/issues/1151

Example usage of this new template:
- https://github.com/canonical/loki-k8s-operator/issues/562
- https://github.com/canonical/cos-lib/issues/173

References:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository