### PR TITLE
fix: Fix constant otel_collector restart on update-status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -461,6 +461,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         if current_hash != old_hash:
             for snap_name in SnapMap.snaps():
                 self._restart_snap(self.snap(snap_name))
+            hash_file.write_text(current_hash)
 
         # Set status
         if self._has_server_cert_relation and not is_tls_ready():


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fix #146 

## Solution
<!-- A summary of the solution addressing the above issue -->
Persist the hash

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Deploy the charm.
2. Configure update-status interval to a short period.
3. Observe that otel collector (systemd service) is not restarted on every update status.


## Upgrade Notes
<!-- To upgrade from an older revision of the charm, ... -->
