### PR TITLE
fix (track 2): observe reconcile action event as condition to refresh certs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -119,10 +119,14 @@ def ensure_logrotate_timer():
     service_start("logrotate.timer", "--now")
 
 
-def hook() -> str:
-    """Return Juju hook name."""
-    return os.environ["JUJU_HOOK_NAME"]
+def event() -> str:
+    """Return Juju hook|action name.
 
+    Refs:
+    - https://github.com/juju/juju/blob/cbb05654c7444dd6bee29e49aff16339f02c34f9/docs/reference/action.md?plain=1#L55
+    - https://github.com/juju/juju/blob/cbb05654c7444dd6bee29e49aff16339f02c34f9/docs/reference/hook.md?plain=1#L1088
+    """
+    return os.environ.get("JUJU_HOOK_NAME") or os.environ.get("JUJU_ACTION_NAME", "")
 
 def _get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
     """Check whether mandatory relations are in place.
@@ -160,9 +164,9 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-        if hook() == "install" or hook() == "upgrade":
+        if event() in ("install", "upgrade"):
             self._install_snaps()
-        elif hook() == "remove":
+        elif event() == "remove":
             # NOTE: We need to clean up the config file and uninstall the snap(s). If we do this
             # on the stop hook, then it will be reverted by the reconciler on `peer_relation_*`
             # hooks. Instead of filtering out these hooks, we do everything in the remove hook.
@@ -198,11 +202,13 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         # This must be run after receive_ca_cert and/or receive_server_cert because they update
         # certs in the /usr/local/share/ca-certificates directory
         # Only refresh certs when they actually change (upgrade-charm or cert relation changes)
-        current_hook = hook()
-        if current_hook in (
+        current_event = event()
+
+        if current_event in (
             "upgrade-charm",
             "receive_ca_cert-relation-changed",
             "receive_server_cert-relation-changed",
+            "reconcile",
         ):
             refresh_certs()
 

--- a/tests/unit/test_refresh_certs.py
+++ b/tests/unit/test_refresh_certs.py
@@ -35,13 +35,13 @@ def test_refresh_certs_called_on_cert_relation_changed(ctx, relation_name, remot
 
 
 @pytest.mark.parametrize(
-    "hook_name,event_method",
+    "event_method",
     [
-        ("update-status", "update_status"),
-        ("config-changed", "config_changed"),
+        "update_status",
+        "config_changed"
     ],
 )
-def test_refresh_certs_not_called_on_non_cert_hooks(ctx, hook_name, event_method):
+def test_refresh_certs_not_called_on_non_cert_hooks(ctx, event_method):
     """Test that refresh_certs is NOT called on non-certificate hooks."""
     # GIVEN a non-certificate hook is being executed
     state = State(leader=True)
@@ -55,3 +55,18 @@ def test_refresh_certs_not_called_on_non_cert_hooks(ctx, hook_name, event_method
 
         # THEN refresh_certs should NOT be called
         mock_refresh_certs.assert_not_called()
+
+def test_refresh_certs_on_reconcile_action_event(ctx):
+    # GIVEN the charm
+    state = State(leader=True)
+
+    # WHEN the `reconcile` action is executed
+    with patch("charm.refresh_certs") as mock_refresh_certs, \
+         patch("integrations._add_alerts"):
+            ctx.run(
+                ctx.on.action('reconcile'),
+                state,
+            )
+
+            # THEN the refresh_certs function MUST have been called once
+            mock_refresh_certs.assert_called_once()


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Cherry picks commit 82e2436 from PR #165 into track 2.

## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
