### PR TITLE
fix: add instance label to log slots

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -362,6 +362,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
                         "juju_model": topology.model,
                         "juju_model_uuid": topology.model_uuid,
                         "snap_name": fstab_entry.owner,
+                        "instance": socket.getfqdn(),
                     },
                 ),
                 pipelines=[f"logs/{self.unit.name}"],

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -247,7 +247,7 @@ class ConfigManager:
                         "action": "upsert",
                         "key": "loki.attribute.labels",
                         # These labels are set in `_scrape_configs` of the `v1.loki_push_api` lib
-                        "value": "container, job, filename, juju_application, juju_charm, juju_model, juju_model_uuid, juju_unit, snap_name, path",
+                        "value": "container, job, filename, juju_application, juju_charm, juju_model, juju_model_uuid, juju_unit, snap_name, path, instance",
                     },
                 ]
             },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Logs collected from log slots do not include the instance `label`.
Fixes #123.

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR ensures that logs coming from log slots have the `instance` label. This will be the FQDN of the machine.
### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
You need to deploy two models to test this change, one on LXD and one on CK8s.
On CK8s, deploy the following bundle:
```yaml
bundle: kubernetes
saas:
  remote-b18c93e8eb094ce385fa5685cda3f042: {}
applications:
  graf:
    charm: grafana-k8s
    channel: 2/edge
    revision: 176
    resources:
      grafana-image: 77
      litestream-image: 46
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: 2/edge
    revision: 212
    resources:
      loki-image: 103
      node-exporter-image: 4
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/stable
    revision: 263
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 162
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - traefik:traefik-route
  - graf:ingress
- - loki:logging
  - remote-b18c93e8eb094ce385fa5685cda3f042:send-loki-logs
- - loki:grafana-source
  - graf:grafana-source
- - loki:ingress
  - traefik:ingress-per-unit
--- # overlay.yaml
applications:
  loki:
    offers:
      loki:
        endpoints:
        - logging
        acl:
          admin: admin

```
On LXD, deploy the following bundle:
```yaml
default-base: ubuntu@24.04/stable
saas:
  loki:
    url: ck8s:admin/test.loki
applications:
  be:
    charm: blackbox-exporter
    channel: latest/edge
    revision: 11
    options:
      probes_file: |+
        scrape_configs:
          - job_name: check-charmhub-connectivity
            metrics_path: /probe
            params:
              module: [icmp]
            static_configs:
              - targets:
                  - charmhub.io
                  - ubuntu.com
                  - thehackernews.com
                  - totallynonexistentaddress.mytotallynonexistentdomain
            relabel_configs:
              - source_labels: [__address__]
                target_label: __param_target
              - source_labels: [__param_target]
                target_label: instance
              - replacement: 10.145.83.108:9115
                target_label: __address__

  otel:
    charm: local:opentelemetry-collector-0
  ubuntu:
    charm: ubuntu
    channel: latest/stable
    revision: 26
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "0":
    constraints: arch=amd64
relations:
- - ubuntu:juju-info
  - otel:juju-info
- - otel:send-loki-logs
  - loki:logging
- - be:juju-info
  - ubuntu:juju-info
- - be:cos-agent
  - otel:cos-agent
```
Go to your Grafana Explore page and enter the query `{juju_application="be"}` to see logs coming from the Blackbox Exporter snap. These logs are added to Otelcol's pipeline through the log slot attribute when instantiating `CosAgentProvider`. The logs for BE should now show you the instance label.
<img width="1820" height="435" alt="image" src="https://github.com/user-attachments/assets/24662fd5-6d12-4a28-b15c-a0d75fb2ff86" />

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
