### PR TITLE
fix (track/2): `cos_agent` regression with fetch-lib

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -217,7 +217,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 47
+LIBPATCH = 48
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -585,9 +585,19 @@ class CharmedDashboard:
                     datasources[template_value["name"]] = template_value["query"].lower()
 
             # Put our own variables in the template
+            # We only want to inject our own dropdowns IFF they are NOT
+            # already in the template coming over relation data.
+            # We'll store all dropdowns in the template from the provider
+            # in a set. We'll add our own if they are not in this set.
+            existing_names = {
+                item.get("name")
+                for item in dict_content["templating"]["list"]
+            }
+
             for d in template_dropdowns:  # type: ignore
-                if d not in dict_content["templating"]["list"]:
+                if d.get("name") not in existing_names:
                     dict_content["templating"]["list"].insert(0, d)
+                    existing_names.add(d.get("name"))
 
         dict_content = cls._replace_template_fields(dict_content, datasources, existing_templates)
         return json.dumps(dict_content)

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -13,7 +13,20 @@
 # limitations under the License.
 
 
-"""Abstractions for stopping, starting and managing system services via systemd.
+"""Legacy Charmhub-hosted systemd library, deprecated in favour of ``charmlibs.systemd``.
+
+WARNING: This library is deprecated and will no longer receive feature updates or bugfixes.
+``charmlibs.systemd`` version 1.0 is a bug-for-bug compatible migration of this library.
+Add 'charmlibs-systemd~=1.0' to your charm's dependencies, and remove this Charmhub-hosted library.
+Then replace `from charms.operator_libs_linux.v0 import systemd` with
+`from charmlibs import systemd`.
+Read more:
+- https://documentation.ubuntu.com/charmlibs
+- https://pypi.org/project/charmlibs-systemd
+
+---
+
+Abstractions for stopping, starting and managing system services via systemd.
 
 This library assumes that your charm is running on a platform that uses systemd. E.g.,
 Centos 7 or later, Ubuntu Xenial (16.04) or later.
@@ -64,7 +77,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 class SystemdError(Exception):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Since `cos_agent` was fixed in:
- https://github.com/canonical/grafana-agent-operator/pull/383

and is released to `0.25` we need to fetch-lib and backport to `track/2`