### PR TITLE
feat: Add s390x platform support for Ubuntu 22.04 and 24.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,9 @@ on:
 
 jobs:
   release:
-    uses: canonical/observability/.github/workflows/charm-release.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-release.yaml@698b788fbe2507b2d55f5bb16a1e41de6bc3c86e
     secrets: inherit
     with:
       provider: machine
       default-track: dev
+      pack-using-remote-build: true

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,8 +26,10 @@ assumes:
 platforms:
   ubuntu@22.04:amd64:
   ubuntu@22.04:arm64:
+  ubuntu@22.04:s390x:
   ubuntu@24.04:amd64:
   ubuntu@24.04:arm64:
+  ubuntu@24.04:s390x:
 
 parts:
   charm:

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -42,13 +42,15 @@ class SnapMap:
     snap_maps = {
         "opentelemetry-collector": {
             # (confinement, arch): revision
-            ("strict", "amd64"): 25,  # 0.130.0
-            ("strict", "arm64"): 26,  # 0.130.0
+            ("strict", "amd64"): 47,  # 0.130.1
+            ("strict", "arm64"): 48,  # 0.130.1
+            ("strict", "s390x"): 45,  # 0.130.1
         },
         "node-exporter": {
             # (confinement, arch): revision
             ("strict", "amd64"): 2154,  # v1.10.2
             ("strict", "arm64"): 2157,  # v1.10.2
+            ("strict", "s390x"): 2158,  # v1.10.2
         },
     }
 


### PR DESCRIPTION
## Issue
A possible alternative fix for https://github.com/canonical/grafana-agent-operator/issues/375.


## Solution
Build otel-collector for s390x and try it out as a replacement.

### Checklist
- [ ] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 