### PR TITLE
fix: Disable the sending queue in the debugexporter

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -633,7 +633,7 @@ class ConfigManager:
                     "use_internal_logger": False,
                     # We disable the sending_queue for now, but this is fixed upstream in rocks
                     # >0.138.0. Remove this config once we bumped our otelcol rock.
-                    "debug": {"sending_queue": {"enabled": False}},
+                    "sending_queue": {"enabled": False},
                 },
                 pipelines=[
                     f"{pipeline}/{self._unit_name}"

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -617,7 +617,7 @@ class ConfigManager:
 
         return metrics_consumer_jobs
 
-    def add_debug_exporters(self, logs: bool=False, metrics: bool=False, traces: bool=False):
+    def add_debug_exporters(self, logs: bool = False, metrics: bool = False, traces: bool = False):
         """Add debug exporters for enabled pipelines.
 
         We set `use_internal_logger` to False to keep the debug output separate from the
@@ -628,6 +628,16 @@ class ConfigManager:
             self.config.add_component(
                 Component.exporter,
                 "debug/juju-config-enabled",
-                {"verbosity": "normal", "use_internal_logger": False},
-                pipelines=[f"{pipeline}/{self._unit_name}" for pipeline, enabled in pipelines.items() if enabled],
+                {
+                    "verbosity": "normal",
+                    "use_internal_logger": False,
+                    # We disable the sending_queue for now, but this is fixed upstream in rocks
+                    # >0.138.0. Remove this config once we bumped our otelcol rock.
+                    "debug": {"sending_queue": {"enabled": False}},
+                },
+                pipelines=[
+                    f"{pipeline}/{self._unit_name}"
+                    for pipeline, enabled in pipelines.items()
+                    if enabled
+                ],
             )


### PR DESCRIPTION
- [ ] Backport this into track/2 and into the k8s charm

## Issue
<!-- What issue is this PR trying to solve? -->
This issue is resolved upstream in:
- https://github.com/open-telemetry/opentelemetry-collector/issues/14138

However, we cannot bump our [snap version](https://github.com/canonical/opentelemetry-collector-snap/blob/30436d0d0021110372c50d67b5c82fd05016b622/snap/snapcraft.yaml#L66) past `0.138.0` since they removed `lokiexporter` in later versions which we rely on.

## Solution
<!-- A summary of the solution addressing the above issue -->
Manually port the upstream fix into our `config_builder` charm code. This is can be removed once we are able to bump the snap version:
- https://github.com/canonical/opentelemetry-collector-operator/issues/200

### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
