### PR TITLE
fix:  `ports` config for otelcol internal metrics endpoint

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -268,7 +268,24 @@ class ConfigBuilder:
                 "output_paths": [INTERNAL_TELEMETRY_LOG_FILE],
             },
         )
-        self.add_telemetry("metrics", {"level": "normal"})
+        self.add_telemetry(
+            "metrics",
+            {
+                "level": "normal",
+                "readers": [
+                    {
+                        "pull": {
+                            "exporter": {
+                                "prometheus": {
+                                    "host": "0.0.0.0",
+                                    "port": self._ports[Port.metrics.name],
+                                }
+                            }
+                        }
+                    }
+                ],
+            },
+        )
 
     def add_component(
         self,

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -377,7 +377,7 @@ def test_build_port_map_invalid_input_raises(overrides, expected_error):
 def test_config_builder_accepts_port_overrides():
     """ConfigBuilder uses the provided port map in add_default_config."""
     # GIVEN a port map with overridden ports
-    port_map = build_port_map("otlp_http=4400,otlp_grpc=4401,health=13200")
+    port_map = build_port_map("otlp_http=4400,otlp_grpc=4401,health=13200,metrics=8889")
     # WHEN creating a ConfigBuilder with those ports and building the config
     config = ConfigBuilder("unit/0", "host0", "1m", "10s", ports=port_map)
     config.add_default_config()
@@ -388,3 +388,6 @@ def test_config_builder_accepts_port_overrides():
     assert str(4401) in otlp_receiver["protocols"]["grpc"]["endpoint"]
     # AND the health_check extension uses the overridden port
     assert str(13200) in built["extensions"]["health_check"]["endpoint"]
+    # AND the internal telemetry metrics endpoint uses the overridden port
+    prometheus_reader = built["service"]["telemetry"]["metrics"]["readers"][0]["pull"]["exporter"]["prometheus"]
+    assert prometheus_reader["port"] == 8889


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Fixes: #213
In tandem with: #215

When changing the metrics port via `juju config otelcol ports="metrics=8889"`, the generated config file was updated correctly — the `prometheus/self-monitoring` scrape target reflected the new port — but otelcol itself kept listening on the old port (`127.0.0.1:8888`). Restarting otelcol did not help because its internal metrics HTTP server always bound to the default port regardless of the charm configuration.

## Solution
<!-- A summary of the solution addressing the above issue -->

The root cause was that `add_default_config()` in `config_builder.py` set up `service.telemetry.metrics` with only `level: normal`, never specifying where otelcol should expose its internal Prometheus metrics endpoint. Without an explicit endpoint, otelcol always defaults to `127.0.0.1:8888`.

The fix adds a `readers` entry to `service.telemetry.metrics` using the prometheus pull exporter format (required by otelcol ≥ v0.86), binding to the port from the charm's `ports` config:

```yaml
service:
  telemetry:
    metrics:
      level: normal
      readers:
        - pull:
            exporter:
              prometheus:
                host: 0.0.0.0
                port: <configured port>
```

This ensures that when the port changes, the YAML changes, the config hash changes, otelcol restarts, and it binds to the newly configured port.

The test `test_config_builder_accepts_port_overrides` was extended to cover the `metrics` port override and assert the `readers` structure is correct.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

The `prometheus/self-monitoring` receiver in the otelcol config acts as a scrape job that collects otelcol's own internal metrics. Its `targets` entry must match the host/port where otelcol's internal Prometheus endpoint is actually bound — both are now derived from the same `Port.metrics` value.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

### Unit test:

Just run unit tests

### Manual test

0. Pack the charm and deploy this bundle:

   ```yaml
   default-base: ubuntu@24.04/stable
   saas:
     prometheus-receive-remote-write:
       url: ck8s:admin/cos.prometheus-receive-remote-write
   applications:
     hwo:
       charm: hardware-observer
       channel: latest/edge
       revision: 819
       resources:
         perccli-deb: 1
         sas2ircu-bin: 1
         sas3ircu-bin: 1
         storcli-deb: 1
     otelcol:
       charm: local:opentelemetry-collector-14
       options:
         ports: node_exporter=9103,loki_http=3503, metrics=8889
     ubuntu:
       charm: ubuntu
       channel: latest/stable
       revision: 26
       num_units: 1
       to:
       - "0"
       constraints: arch=amd64
       storage:
         block: loop,100M
         files: rootfs,100M
   machines:
     "0":
       constraints: arch=amd64
   relations:
   - - ubuntu:juju-info
     - hwo:general-info
   - - otelcol:cos-agent
     - hwo:cos-agent
   - - otelcol:juju-info
     - ubuntu:juju-info
   - - otelcol:send-remote-write
     - prometheus-receive-remote-write:receive-remote-write
   ```


1. Deploy the charm and verify otelcol is running normally in the VM with the default port:
   ```
   sudo ss -atunlp | grep otelcol | grep 88
   tcp   LISTEN 0      4096                   *:8888             *:*    users:(("otelcol",pid=162669,fd=3))
   ```
2. Change the metrics port:
   ```
   juju config otelcol ports="metrics=8889"
   ```
3. Wait for the charm to reconcile, then verify in the VM:
   ```
   sudo ss -atunlp | grep otelcol | grep 88
   tcp   LISTEN 0      4096                   *:8889             *:*    users:(("otelcol",pid=164133,fd=3))
   ```
4. Verify in the VM the generated config file at `/etc/otelcol/config.d/<unit>.yaml` has both:
   - `prometheus/self-monitoring` target pointing to `0.0.0.0:8889`
   - `service.telemetry.metrics.readers[0].pull.exporter.prometheus.port: 8889`


5. Reset to default
   ```
   juju config otelcol --reset ports
   ```
6. And verify in the VM
   ```
   sudo ss -atunlp | grep otelcol | grep 88
   tcp   LISTEN 0      4096                   *:8888             *:*    users:(("otelcol",pid=165524,fd=3))
   ```


