### PR TITLE
fix(track/2): Escape `$` in Prometheus scrape configs

### DIFF
--- a/src/config_builder.py
+++ b/src/config_builder.py
@@ -1,9 +1,11 @@
 """Helper module to build the configuration for OpenTelemetry Collector."""
 
+import copy
 import hashlib
 import logging
 from enum import Enum, unique
-from typing import Any, Dict, List, Literal, Optional, Set, Union
+import re
+from typing import Any, Dict, List, Literal, Optional, Set, Union, cast
 
 import yaml
 
@@ -219,6 +221,7 @@ class ConfigBuilder:
             self._scrape_interval,
             self._scrape_timeout,
         )
+        self._sanitize_prometheus_scrape_configs()
         self._add_exporter_insecure_skip_verify(self._exporter_skip_verify)
         return yaml.safe_dump(self._config)
 
@@ -428,8 +431,48 @@ class ConfigBuilder:
         """Set the `scrape_interval` and `scrape_timeout` for all scrape_configs in every prometheus receiver."""
         receivers = self._config.get("receivers", {})
         for name, receiver in receivers.items():
-            if name.split("/")[0] == "prometheus":
+            if name.startswith("prometheus/"):
                 scrape_configs = receiver.get("config", {}).get("scrape_configs", [])
                 for scrape_cfg in scrape_configs:
                     scrape_cfg["scrape_interval"] = interval
                     scrape_cfg["scrape_timeout"] = timeout
+
+    @classmethod
+    def _escape_dollars(cls, value: Any) -> Any:
+        """Recursively escape bare `$` signs in strings within a nested structure."""
+        match value:
+            case str():
+                return re.sub(r'(?<!\$)\$(?!\$)', '$$', value)
+            case dict():
+                return {k: cls._escape_dollars(v) for k, v in value.items()}
+            case list():
+                return [cls._escape_dollars(item) for item in value]
+            case _:
+                return value
+
+    @classmethod
+    def _sanitize_escape_prometheus_scrape_configs(cls, scrape_configs: List[Dict]) -> List[Dict]:
+        """Escape $ signs in Prometheus scrape configs for otelcol compatibility.
+
+        The OpenTelemetry Collector interprets ${VAR} and $VAR as environment-variable
+        references. Prometheus relabeling rules legitimately use ${1}, ${2}, etc. as
+        capture-group back-references. To prevent otelcol from misinterpreting these,
+        every `$` must be doubled to `$$`, which otelcol treats as a literal dollar sign.
+
+        Already-escaped `$$` sequences are left unchanged (idempotent).
+
+        Args:
+            scrape_configs: list of scrape config dicts (may contain nested dicts/lists/strings).
+
+        Returns:
+            A deep copy of the scrape configs with all bare `$` signs escaped to `$$`.
+        """
+        return [cast(Dict, cls._escape_dollars(copy.deepcopy(job))) for job in scrape_configs]
+
+    def _sanitize_prometheus_scrape_configs(self):
+        """Escape any $ in any prometheus receiver's scrape configs."""
+        for name, receiver in self._config.get("receivers", {}).items():
+            if name.startswith("prometheus/"):
+                scrape_configs = receiver.get("config", {}).get("scrape_configs", [])
+                sanitized_scrape_configs = self._sanitize_escape_prometheus_scrape_configs(scrape_configs)
+                receiver["config"]["scrape_configs"] = sanitized_scrape_configs

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 import copy
 
-from config_builder import ConfigBuilder, Component, Port, build_port_map
+from src.config_builder import ConfigBuilder, Component, Port, build_port_map
 
 
 @pytest.mark.parametrize("pipelines", ([], ["logs", "metrics", "traces"]))
@@ -391,3 +391,107 @@ def test_config_builder_accepts_port_overrides():
     # AND the internal telemetry metrics endpoint uses the overridden port
     prometheus_reader = built["service"]["telemetry"]["metrics"]["readers"][0]["pull"]["exporter"]["prometheus"]
     assert prometheus_reader["port"] == 8889
+
+
+@pytest.mark.parametrize(
+    "input_replacement,expected_replacement",
+    [
+        # Single capture group ${1}
+        ("${1}.juju-73d163-3-lxd-0", "$${1}.juju-73d163-3-lxd-0"),
+        # Multiple capture groups ${1} and ${2}
+        ("${1}-${2}", "$${1}-$${2}"),
+        # Plain $var env-var-like
+        ("$MY_VAR", "$$MY_VAR"),
+        # Already escaped $$ — must be idempotent
+        ("$${1}.juju-73d163-3-lxd-0", "$${1}.juju-73d163-3-lxd-0"),
+        # No dollar signs — unchanged
+        ("static-replacement", "static-replacement"),
+        # Empty string
+        ("", ""),
+    ],
+)
+def test_sanitize_escape_prometheus_scrape_configs_parametrized(
+    input_replacement, expected_replacement
+):
+    """Test that bare $ signs in relabel_configs replacement fields are properly escaped."""
+    # GIVEN a scrape config with a relabeling rule containing a replacement value
+    scrape_configs = [
+        {
+            "job_name": "test_job",
+            "relabel_configs": [
+                {
+                    "action": "replace",
+                    "regex": "([^.]+).*",
+                    "replacement": input_replacement,
+                }
+            ],
+        }
+    ]
+
+    expected_scrape_configs = [
+        {
+            "job_name": "test_job",
+            "relabel_configs": [
+                {
+                    "action": "replace",
+                    "regex": "([^.]+).*",
+                    "replacement": expected_replacement,
+                }
+            ],
+        }
+    ]
+
+    # WHEN sanitize_escape_prometheus_scrape_configs is called
+    result = ConfigBuilder._sanitize_escape_prometheus_scrape_configs(scrape_configs)
+
+    # THEN the scrape config is correctly escaped
+    assert result == expected_scrape_configs
+
+
+def test_sanitize_escape_prometheus_scrape_configs_multiple_jobs_mixed():
+    """Test that multiple jobs are handled correctly, including already-escaped ones."""
+    # GIVEN two jobs: one with bare $ signs, one already escaped
+    scrape_configs = [
+        {
+            "job_name": "job_bare",
+            "relabel_configs": [{"replacement": "${1}.host"}],
+        },
+        {
+            "job_name": "job_already_escaped",
+            "relabel_configs": [{"replacement": "$${1}.host"}],
+        },
+    ]
+
+    # WHEN sanitize_escape_prometheus_scrape_configs is called
+    result = ConfigBuilder._sanitize_escape_prometheus_scrape_configs(scrape_configs)
+
+    # THEN bare $ in job_bare is escaped
+    assert result[0]["relabel_configs"][0]["replacement"] == "$${1}.host"
+    # AND already-escaped $$ in job_already_escaped is unchanged
+    assert result[1]["relabel_configs"][0]["replacement"] == "$${1}.host"
+
+
+def test_sanitize_escape_prometheus_scrape_configs_no_mutation():
+    """Test that the original input is not mutated (deep copy guarantee)."""
+    # GIVEN a scrape config with bare $ signs
+    original = [{"relabel_configs": [{"replacement": "${1}.host"}]}]
+    original_copy = copy.deepcopy(original)
+
+    # WHEN sanitize_escape_prometheus_scrape_configs is called
+    ConfigBuilder._sanitize_escape_prometheus_scrape_configs(original)
+
+    # THEN the original input is not mutated
+    assert original == original_copy
+
+
+def test_sanitize_escape_prometheus_scrape_configs_idempotent():
+    """Test that calling the method twice returns the same result (idempotent)."""
+    # GIVEN a scrape config with bare $ signs
+    scrape_configs = [{"relabel_configs": [{"replacement": "${1}.host"}]}]
+
+    # WHEN sanitize_escape_prometheus_scrape_configs is called twice
+    once = ConfigBuilder._sanitize_escape_prometheus_scrape_configs(scrape_configs)
+    twice = ConfigBuilder._sanitize_escape_prometheus_scrape_configs(once)
+
+    # THEN the result is the same both times
+    assert once == twice


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Same as:
- https://github.com/canonical/opentelemetry-collector-operator/pull/242

but a backport into track/2.