### PR TITLE
fix: No metric normalization in prometheus components

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,10 +77,6 @@ requires:
       `cos-agent` is a dedicated relation for the grafana agent machine
       charm. It will allow you to set up custom scrape jobs, fetch files
       from arbitrary locations, send alert rules, dashboards, etc.
-
-      The prometheus receiver config has ``trim_metric_suffixes`` set to
-      ``true`` to restore the original metric names used in OpenTelemetry
-      instrumentation. This maintains parity with grafana-agent.
     interface: cos_agent
     scope: container
     optional: true
@@ -91,12 +87,7 @@ requires:
   metrics-endpoint:
     interface: prometheus_scrape
     optional: true
-    description: |
-      To scrape other charms' metrics endpoints.
-
-      The prometheus receiver config has ``trim_metric_suffixes`` set to
-      ``true`` to restore the original metric names used in OpenTelemetry
-      instrumentation. This maintains parity with grafana-agent.
+    description: To scrape other charms' metrics endpoints.
   send-remote-write:
     interface: prometheus_remote_write
     optional: true

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,6 +77,10 @@ requires:
       `cos-agent` is a dedicated relation for the grafana agent machine
       charm. It will allow you to set up custom scrape jobs, fetch files
       from arbitrary locations, send alert rules, dashboards, etc.
+
+      The prometheus receiver config has ``trim_metric_suffixes`` set to
+      ``true`` to restore the original metric names used in OpenTelemetry
+      instrumentation. This maintains parity with grafana-agent.
     interface: cos_agent
     scope: container
     optional: true
@@ -87,7 +91,12 @@ requires:
   metrics-endpoint:
     interface: prometheus_scrape
     optional: true
-    description: To scrape other charms' metrics endpoints.
+    description: |
+      To scrape other charms' metrics endpoints.
+
+      The prometheus receiver config has ``trim_metric_suffixes`` set to
+      ``true`` to restore the original metric names used in OpenTelemetry
+      instrumentation. This maintains parity with grafana-agent.
   send-remote-write:
     interface: prometheus_remote_write
     optional: true
@@ -95,9 +104,9 @@ requires:
       To forward collected metrics to a Prometheus backend.
 
       The remote write exporter config has ``add_metric_suffixes`` set to
-      ``false`` to not add suffixes to metric names based on the type of the
-      metric (e.g. _total for counters). This is to maintain parity with
-      grafana-agent, and will eventually be deprecated.
+      ``false`` to convert the OTLP metric names used in OpenTelemetry
+      instrumentation to Prometheus-compatible names. This maintains parity
+      with grafana-agent.
   send-loki-logs:
     interface: loki_push_api
     optional: true

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -91,7 +91,13 @@ requires:
   send-remote-write:
     interface: prometheus_remote_write
     optional: true
-    description: To forward collected metrics to a Prometheus backend.
+    description: |
+      To forward collected metrics to a Prometheus backend.
+
+      The remote write exporter config has ``add_metric_suffixes`` set to
+      ``false`` to not add suffixes to metric names based on the type of the
+      metric (e.g. _total for counters). This is to maintain parity with
+      grafana-agent, and will eventually be deprecated.
   send-loki-logs:
     interface: loki_push_api
     optional: true

--- a/src/charm.py
+++ b/src/charm.py
@@ -325,7 +325,10 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             config_manager.config.add_component(
                 Component.receiver,
                 f"prometheus/cos-agent/{self.unit.name}",
-                {"config": {"scrape_configs": cos_agent.metrics_jobs}},
+                {
+                    "config": {"scrape_configs": cos_agent.metrics_jobs},
+                    "trim_metric_suffixes": True,
+                },
                 pipelines=[f"metrics/{self.unit.name}"],
             )
         if self.unit.is_leader():

--- a/src/charm.py
+++ b/src/charm.py
@@ -325,10 +325,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             config_manager.config.add_component(
                 Component.receiver,
                 f"prometheus/cos-agent/{self.unit.name}",
-                {
-                    "config": {"scrape_configs": cos_agent.metrics_jobs},
-                    "trim_metric_suffixes": True,
-                },
+                {"config": {"scrape_configs": cos_agent.metrics_jobs}},
                 pipelines=[f"metrics/{self.unit.name}"],
             )
         if self.unit.is_leader():

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -366,7 +366,10 @@ class ConfigManager:
         self.config.add_component(
             Component.receiver,
             f"prometheus/metrics-endpoint/{self._unit_name}",
-            config={"config": {"scrape_configs": jobs}},
+            config={
+                "config": {"scrape_configs": jobs},
+                "trim_metric_suffixes": True,
+            },
             pipelines=[f"metrics/{self._unit_name}"],
         )
 
@@ -411,14 +414,12 @@ class ConfigManager:
                 "insecure": insecure,
                 "insecure_skip_verify": self._insecure_skip_verify,
             }
-            exporter_type = 'otlp' if otlp_endpoint.protocol == 'grpc' else 'otlphttp'
+            exporter_type = "otlp" if otlp_endpoint.protocol == "grpc" else "otlphttp"
             self.config.add_component(
                 Component.exporter,
                 f"{exporter_type}/rel-{rel_id}/{self._unit_name}",
                 {"endpoint": otlp_endpoint.endpoint, "tls": tls_config},
-                pipelines=[
-                    f"{_type}/{self._unit_name}" for _type in otlp_endpoint.telemetries
-                ],
+                pipelines=[f"{_type}/{self._unit_name}" for _type in otlp_endpoint.telemetries],
             )
 
     def add_traces_ingestion(
@@ -708,7 +709,9 @@ class ConfigManager:
                 try:
                     component = Component(config_type)
                 except ValueError:
-                    logger.warning("wrong component type '%s' in external config, skipping", config_type)
+                    logger.warning(
+                        "wrong component type '%s' in external config, skipping", config_type
+                    )
                     continue
 
                 if not isinstance(config, dict):
@@ -723,6 +726,11 @@ class ConfigManager:
                         component,
                         comp_name,
                         cnf,
-                        pipelines=[f"{getattr(p, 'value', p)}/{self._unit_name}" for p in configs["pipelines"]],
+                        pipelines=[
+                            f"{getattr(p, 'value', p)}/{self._unit_name}"
+                            for p in configs["pipelines"]
+                        ],
                     )
-                    logger.debug("component type: '%s', name: '%s' added to config", config_type, comp_name)
+                    logger.debug(
+                        "component type: '%s', name: '%s' added to config", config_type, comp_name
+                    )

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -366,10 +366,7 @@ class ConfigManager:
         self.config.add_component(
             Component.receiver,
             f"prometheus/metrics-endpoint/{self._unit_name}",
-            config={
-                "config": {"scrape_configs": jobs},
-                "trim_metric_suffixes": True,
-            },
+            config={"config": {"scrape_configs": jobs}},
             pipelines=[f"metrics/{self._unit_name}"],
         )
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -380,6 +380,7 @@ class ConfigManager:
                 {
                     "endpoint": endpoint["url"],
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
+                    "add_metric_suffixes": False,
                     **self.prometheus_remotewrite_wal_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -72,6 +72,7 @@ def test_add_remote_write():
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {
         "endpoint": "http://192.168.1.244/cos-prometheus-0/api/v1/write",
+        "add_metric_suffixes": False,
         "tls": {
             "insecure_skip_verify": True,
         },

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -106,6 +106,7 @@ def test_add_prometheus_scrape():
         }
     ]
     expected_prom_recv_cfg = {
+        "trim_metric_suffixes": True,
         "config": {
             "scrape_configs": [
                 {
@@ -117,7 +118,7 @@ def test_add_prometheus_scrape():
                     "tls_config": {"insecure_skip_verify": True},
                 },
             ],
-        }
+        },
     }
     config_manager.add_prometheus_scrape_jobs(first_job)
     # THEN it exists in the prometheus receiver config

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -106,7 +106,6 @@ def test_add_prometheus_scrape():
         }
     ]
     expected_prom_recv_cfg = {
-        "trim_metric_suffixes": True,
         "config": {
             "scrape_configs": [
                 {


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Resolves partially https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/232

The core of the conversation will be held in:
- https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/238

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
Any queries|dashboards that were created prior to adopting the otelcol charm and expecting the e.g., `_total` suffix (among other suffixes) need to be updated because we have disabled this in the `send-remote-write` integration.