### PR TITLE
feat: Use the provider's insecure flag in OTLP databag

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -91,7 +91,13 @@ requires:
   send-remote-write:
     interface: prometheus_remote_write
     optional: true
-    description: To forward collected metrics to a Prometheus backend.
+    description: |
+      To forward collected metrics to a Prometheus backend.
+
+      The remote write exporter config has ``add_metric_suffixes`` set to
+      ``false`` to convert the OTLP metric names used in OpenTelemetry
+      instrumentation to Prometheus-compatible names. This maintains parity
+      with grafana-agent.
   send-loki-logs:
     interface: loki_push_api
     optional: true

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -335,7 +335,7 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import yaml
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 57
+LIBPATCH = 58
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -398,6 +398,14 @@ DEFAULT_RELATION_NAME = "metrics-endpoint"
 RELATION_INTERFACE_NAME = "prometheus_scrape"
 
 DEFAULT_ALERT_RULES_RELATIVE_PATH = "./src/prometheus_alert_rules"
+
+FallbackScrapeProtocol = Literal[
+    "PrometheusProto",
+    "OpenMetricsText0.0.1",
+    "OpenMetricsText1.0.0",
+    "PrometheusText0.0.4",
+    "PrometheusText1.0.0",
+]
 
 
 class PrometheusConfig:
@@ -939,7 +947,12 @@ class MetricsEndpointConsumer(Object):
 
     on = MonitoringEvents()  # pyright: ignore
 
-    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        fallback_scrape_protocol: Optional[FallbackScrapeProtocol] = None,
+    ):
         """A Prometheus based Monitoring service.
 
         Args:
@@ -950,6 +963,17 @@ class MetricsEndpointConsumer(Object):
                 It is strongly advised not to change the default, so that people
                 deploying your charm will have a consistent experience with all
                 other charms that consume metrics endpoints.
+            fallback_scrape_protocol: an optional fallback protocol to use when the
+                Content-Type header of a scrape response is missing or invalid. Supported
+                values: "PrometheusProto", "OpenMetricsText0.0.1", "OpenMetricsText1.0.0",
+                "PrometheusText0.0.4", "PrometheusText1.0.0". Ref:
+                https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config.
+                This had to be added after we bumped to Prometheus workload major version 3. Starting in major 3,
+                Prometheus no longer defaults to the Prometheus text format (PrometheusText0.0.4)
+                when the Content-Type header is missing or invalid, and instead fails the scrape with an error.
+                This parameter should only be used by MetricsEndpointConsumers that use Prometheus 3 and above, as setting
+                this key in the scrape configs of Prometheus 2 will result in the error:
+                "field fallback_scrape_protocol not found in type config.ScrapeConfig".
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -968,6 +992,7 @@ class MetricsEndpointConsumer(Object):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
+        self._fallback_scrape_protocol = fallback_scrape_protocol
         self._tool = CosTool(self._charm)
         events = self._charm.on[relation_name]
         self.framework.observe(events.relation_changed, self._on_metrics_provider_relation_changed)
@@ -1261,6 +1286,11 @@ class MetricsEndpointConsumer(Object):
 
         # For https scrape targets we still do not render a `tls_config` section because certs
         # are expected to be made available by the charm via the `update-ca-certificates` mechanism.
+
+        if self._fallback_scrape_protocol:
+            for job in scrape_configs:
+                job["fallback_scrape_protocol"] = self._fallback_scrape_protocol
+
         return scrape_configs
 
     def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str, str]]:

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -2,7 +2,6 @@
 
 import logging
 from typing import Any, Dict, List, Literal, Optional, Set
-from urllib.parse import urlparse
 
 import yaml
 
@@ -405,9 +404,8 @@ class ConfigManager:
 
         # Exporter config
         for rel_id, otlp_endpoint in relation_map.items():
-            insecure = urlparse(otlp_endpoint.endpoint).scheme == "http"
             tls_config: Dict[str, Any] = {
-                "insecure": insecure,
+                "insecure": otlp_endpoint.insecure,
                 "insecure_skip_verify": self._insecure_skip_verify,
             }
             exporter_type = 'otlp' if otlp_endpoint.protocol == 'grpc' else 'otlphttp'

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -379,6 +379,7 @@ class ConfigManager:
                 {
                     "endpoint": endpoint["url"],
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
+                    "add_metric_suffixes": False,
                     **self.prometheus_remotewrite_wal_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],
@@ -408,14 +409,12 @@ class ConfigManager:
                 "insecure": otlp_endpoint.insecure,
                 "insecure_skip_verify": self._insecure_skip_verify,
             }
-            exporter_type = 'otlp' if otlp_endpoint.protocol == 'grpc' else 'otlphttp'
+            exporter_type = "otlp" if otlp_endpoint.protocol == "grpc" else "otlphttp"
             self.config.add_component(
                 Component.exporter,
                 f"{exporter_type}/rel-{rel_id}/{self._unit_name}",
                 {"endpoint": otlp_endpoint.endpoint, "tls": tls_config},
-                pipelines=[
-                    f"{_type}/{self._unit_name}" for _type in otlp_endpoint.telemetries
-                ],
+                pipelines=[f"{_type}/{self._unit_name}" for _type in otlp_endpoint.telemetries],
             )
 
     def add_traces_ingestion(
@@ -705,7 +704,9 @@ class ConfigManager:
                 try:
                     component = Component(config_type)
                 except ValueError:
-                    logger.warning("wrong component type '%s' in external config, skipping", config_type)
+                    logger.warning(
+                        "wrong component type '%s' in external config, skipping", config_type
+                    )
                     continue
 
                 if not isinstance(config, dict):
@@ -720,6 +721,11 @@ class ConfigManager:
                         component,
                         comp_name,
                         cnf,
-                        pipelines=[f"{getattr(p, 'value', p)}/{self._unit_name}" for p in configs["pipelines"]],
+                        pipelines=[
+                            f"{getattr(p, 'value', p)}/{self._unit_name}"
+                            for p in configs["pipelines"]
+                        ],
                     )
-                    logger.debug("component type: '%s', name: '%s' added to config", config_type, comp_name)
+                    logger.debug(
+                        "component type: '%s', name: '%s' added to config", config_type, comp_name
+                    )

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -72,6 +72,7 @@ def test_add_remote_write():
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {
         "endpoint": "http://192.168.1.244/cos-prometheus-0/api/v1/write",
+        "add_metric_suffixes": False,
         "tls": {
             "insecure_skip_verify": True,
         },
@@ -116,7 +117,7 @@ def test_add_prometheus_scrape():
                     "tls_config": {"insecure_skip_verify": True},
                 },
             ],
-        }
+        },
     }
     config_manager.add_prometheus_scrape_jobs(first_job)
     # THEN it exists in the prometheus receiver config

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -230,8 +230,9 @@ def test_add_otlp_forwarding():
             0: OtlpEndpoint(
                 **{
                     "protocol": "grpc",
-                    "endpoint": "https://1.2.3.4:grpc-port",
+                    "endpoint": "1.2.3.4:grpc-port",
                     "telemetries": ["metrics", "traces"],
+                    "insecure": False,
                 }
             ),
             1: OtlpEndpoint(
@@ -239,13 +240,15 @@ def test_add_otlp_forwarding():
                     "protocol": "http",
                     "endpoint": "http://host-1:http-port",
                     "telemetries": ["logs"],
+                    "insecure": True,
                 }
             ),
             2: OtlpEndpoint(
                 **{
                     "protocol": "grpc",
-                    "endpoint": "https://host-2:grpc-port",
+                    "endpoint": "host-2:grpc-port",
                     "telemetries": ["logs", "traces"],
+                    "insecure": True,
                 }
             ),
         }
@@ -254,7 +257,7 @@ def test_add_otlp_forwarding():
     # THEN the exporter config contains appropriate "otlp" and "otlphttp" exporters
     expected_exporters = {
         f"otlp/rel-0/{unit_name}": {
-            "endpoint": "https://1.2.3.4:grpc-port",
+            "endpoint": "1.2.3.4:grpc-port",
             "tls": {"insecure": False, "insecure_skip_verify": True},
         },
         f"otlphttp/rel-1/{unit_name}": {
@@ -262,8 +265,8 @@ def test_add_otlp_forwarding():
             "tls": {"insecure": True, "insecure_skip_verify": True},
         },
         f"otlp/rel-2/{unit_name}": {
-            "endpoint": "https://host-2:grpc-port",
-            "tls": {"insecure": False, "insecure_skip_verify": True},
+            "endpoint": "host-2:grpc-port",
+            "tls": {"insecure": True, "insecure_skip_verify": True},
         },
     }
     # AND the exporters are added to the appropriate pipelines


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Since this PR is merged:
- https://github.com/canonical/charmlibs/pull/378

we should rely on the provider specifying whether or not the communication is secure. We need this because gRPC communication may not have a scheme, which we were using to determine "secure" communication.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 