### PR TITLE
fix(track/2): No metric normalization in prometheus components

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -91,7 +91,13 @@ requires:
   send-remote-write:
     interface: prometheus_remote_write
     optional: true
-    description: To forward collected metrics to a Prometheus backend.
+    description: |
+      To forward collected metrics to a Prometheus backend.
+
+      The remote write exporter config has ``add_metric_suffixes`` set to
+      ``false`` to convert the OTLP metric names used in OpenTelemetry
+      instrumentation to Prometheus-compatible names. This maintains parity
+      with grafana-agent.
   send-loki-logs:
     interface: loki_push_api
     optional: true

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -378,13 +378,11 @@ class ConfigManager:
                 {
                     "endpoint": endpoint["url"],
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
+                    "add_metric_suffixes": False,
                     **self.prometheus_remotewrite_wal_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],
             )
-
-        # TODO Receive alert rules via remote write
-        # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37277
 
     def add_traces_ingestion(
         self,

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -69,6 +69,7 @@ def test_add_remote_write():
     # WHEN a remote write exporter is added to the config
     expected_remote_write_cfg = {
         "endpoint": "http://192.168.1.244/cos-prometheus-0/api/v1/write",
+        "add_metric_suffixes": False,
         "tls": {
             "insecure_skip_verify": True,
         },
@@ -113,7 +114,7 @@ def test_add_prometheus_scrape():
                     "tls_config": {"insecure_skip_verify": True},
                 },
             ],
-        }
+        },
     }
     config_manager.add_prometheus_scrape_jobs(first_job)
     # THEN it exists in the prometheus receiver config


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Same as:
- https://github.com/canonical/opentelemetry-collector-operator/pull/247

but backport into track/2.

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
Any queries|dashboards that were created prior to adopting the otelcol charm and expecting the e.g., `_total` suffix (among other suffixes) need to be updated because we have disabled this in the `send-remote-write` integration.