### PR TITLE
feat(terraform): add channel validation and split outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 .vscode/
 cos-tool*
 version
+# Terraform
+**/.terraform/*
+**/.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -39,5 +39,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
-| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,9 +2,16 @@ output "app_name" {
   value = juju_application.opentelemetry_collector.name
 }
 
-output "endpoints" {
+output "provides" {
   value = {
-    # Requires
+    grafana_dashboards_provider = "grafana-dashboards-provider",
+    receive_loki_logs           = "receive-loki-logs",
+    receive_traces              = "receive-traces",
+  }
+}
+
+output "requires" {
+  value = {
     cloud_config                = "cloud-config",
     cos_agent                   = "cos-agent",
     grafana_dashboards_consumer = "grafana-dashboards-consumer",
@@ -17,10 +24,5 @@ output "endpoints" {
     send_otlp                   = "send-otlp",
     send_remote_write           = "send-remote-write",
     send_traces                 = "send-traces",
-
-    # Provides
-    grafana_dashboards_provider = "grafana-dashboards-provider",
-    receive_loki_logs           = "receive-loki-logs",
-    receive_traces              = "receive-traces",
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

Split the  output into separate  and  outputs.

See canonical/alertmanager-k8s-operator#403 and canonical/alertmanager-k8s-operator#396 for reference.