### PR TITLE
fix: snaps not updated on charm refresh due to wrong hook name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -41,7 +41,7 @@ from constants import (
     SERVER_CERT_PATH,
     SERVER_CERT_PRIVATE_KEY_PATH,
 )
-from singleton_snap import SingletonSnapManager, SnapRegistrationFile
+from singleton_snap import SingletonSnapManager, normalize_unit_name
 from snap_fstab import SnapFstab
 from snap_management import (
     SnapMap,
@@ -170,7 +170,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         super().__init__(framework)
         self.external_configs: List[Dict[str, Any]] = []
         self.external_secret_files: Dict[str, str] = {}
-        if event() in ("install", "upgrade"):
+        if event() in ("install", "upgrade-charm"):
             self._install_snaps()
         elif event() == "remove":
             # NOTE: We need to clean up the config file and uninstall the snap(s). If we do this
@@ -507,7 +507,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             config_manager.add_custom_processors(custom_processors)
 
         # Push the config and Push the config and deploy/update
-        config_filename = f"{SnapRegistrationFile._normalize_name(self.unit.name)}.yaml"
+        config_filename = f"{normalize_unit_name(self.unit.name)}.yaml"
         config_path = LocalPath(os.path.join(CONFIG_FOLDER, config_filename))
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(config_manager.config.build())
@@ -614,8 +614,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         """Coordinate node-exporter snap removal."""
         manager = SingletonSnapManager(self.unit.name)
         snap_name = "node-exporter"
-        snap_revision = SnapMap.get_revision(snap_name)
-        manager.unregister(snap_name, snap_revision)
+        manager.unregister_all_for_unit(snap_name)
         if not manager.is_used_by_other_units(snap_name):
             self._remove_snap(snap_name)
 
@@ -623,10 +622,9 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         """Coordinate opentelemetry-collector snap and config file removal."""
         manager = SingletonSnapManager(self.unit.name)
         snap_name = "opentelemetry-collector"
-        snap_revision = SnapMap.get_revision(snap_name)
-        manager.unregister(snap_name, snap_revision)
+        manager.unregister_all_for_unit(snap_name)
         if manager.is_used_by_other_units(snap_name):
-            config_filename = f"{SnapRegistrationFile._normalize_name(self.unit.name)}.yaml"
+            config_filename = f"{normalize_unit_name(self.unit.name)}.yaml"
             config_path = LocalPath(os.path.join(CONFIG_FOLDER, config_filename))
             try:
                 config_path.unlink()

--- a/src/singleton_snap.py
+++ b/src/singleton_snap.py
@@ -22,15 +22,9 @@ def _get_registrations(
     Malformed files and files for other snaps are silently skipped.
     """
     result = []
-    try:
-        filenames = os.listdir(lock_dir)
-    except FileNotFoundError:
-        return result
-    for filename in filenames:
-        if not filename.startswith(SnapRegistrationFile.PREFIX):
-            continue
+    for path in lock_dir.glob(f"{SnapRegistrationFile.PREFIX}*"):
         try:
-            reg = SnapRegistrationFile.from_filename(filename)
+            reg = SnapRegistrationFile.from_filename(path.name)
         except (ValueError, IndexError):
             continue
         if reg.snap_name == snap_name:

--- a/src/singleton_snap.py
+++ b/src/singleton_snap.py
@@ -17,7 +17,7 @@ def normalize_unit_name(name: str) -> str:
 def _get_registrations(
     lock_dir: Path, snap_name: str
 ) -> List["SnapRegistrationFile"]:
-    """Return all SnapRegistrationFile objects for well-formed lockfiles matching snap_name.
+    """Return all SnapRegistrationFile objects across all units for well-formed lockfiles matching snap_name.
 
     Malformed files and files for other snaps are silently skipped.
     """

--- a/src/singleton_snap.py
+++ b/src/singleton_snap.py
@@ -1,11 +1,41 @@
 """File-based registration for singleton snap operations."""
 
-import errno
 import os
-import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Set
+from typing import List, Optional, Set
+
+
+def normalize_unit_name(name: str) -> str:
+    """Normalize a Juju unit name by replacing the '/' separator with '_'.
+
+    Juju uses '<app>/<n>' (e.g. 'otelcol/2') but '/' is not valid in filenames,
+    so it is replaced with '_' (e.g. 'otelcol_2').
+    """
+    return name.replace("/", "_")
+
+def _get_registrations(
+    lock_dir: Path, snap_name: str
+) -> List["SnapRegistrationFile"]:
+    """Return all SnapRegistrationFile objects for well-formed lockfiles matching snap_name.
+
+    Malformed files and files for other snaps are silently skipped.
+    """
+    result = []
+    try:
+        filenames = os.listdir(lock_dir)
+    except FileNotFoundError:
+        return result
+    for filename in filenames:
+        if not filename.startswith(SnapRegistrationFile.PREFIX):
+            continue
+        try:
+            reg = SnapRegistrationFile.from_filename(filename)
+        except (ValueError, IndexError):
+            continue
+        if reg.snap_name == snap_name:
+            result.append(reg)
+    return result
 
 
 @dataclass
@@ -14,11 +44,11 @@ class SnapRegistrationFile:
 
     The files are stored in the lock directory and follow a specific naming convention.
 
-    The filename format is: LCK..<snap_name>__<revision>--<unit_name>
-    Example: LCK..opentelemetry-collector__10--otelcol-0
+    The filename format is: LCK..<snap_name>--rev<revision>__<unit_name>
+    Example: LCK..opentelemetry-collector--rev10__otelcol_0
 
     Attributes:
-        unit_name: Name of the unit registering the snap
+        unit_name: Normalized name of the unit registering the snap (slashes replaced with underscores)
         snap_name: Name of the snap being registered
         snap_revision: Revision of the snap being registered
     """
@@ -31,6 +61,10 @@ class SnapRegistrationFile:
     SEPARATOR_REVISION = "--rev"
     SEPARATOR_UNIT = "__"
 
+    def __post_init__(self):
+        """Normalize unit_name on construction."""
+        self.unit_name = normalize_unit_name(self.unit_name)
+
     @property
     def filename(self):
         """Assemble the filename."""
@@ -40,27 +74,21 @@ class SnapRegistrationFile:
             f"{self.SEPARATOR_REVISION}"
             f"{str(self.snap_revision)}"
             f"{self.SEPARATOR_UNIT}"
-            f"{SnapRegistrationFile._normalize_name(self.unit_name)}"
+            f"{self.unit_name}"
         )
 
     @staticmethod
     def from_filename(filename: str):
         """Build a SnapRegistrationFile by parsing its filename."""
-        # Remove the PREFIX
-        _, filename = filename.split(SnapRegistrationFile.PREFIX)
-        # Extract the information one by one
-        snap_name, filename = filename.split(SnapRegistrationFile.SEPARATOR_REVISION)
-        snap_revision, unit_name = filename.split(SnapRegistrationFile.SEPARATOR_UNIT)
+        after_prefix = filename.removeprefix(SnapRegistrationFile.PREFIX)
+        snap_name, after_snap = after_prefix.split(SnapRegistrationFile.SEPARATOR_REVISION)
+        snap_revision, unit_name = after_snap.split(SnapRegistrationFile.SEPARATOR_UNIT)
         return SnapRegistrationFile(
             unit_name=unit_name,
             snap_name=snap_name,
             snap_revision=int(snap_revision),
         )
 
-    @classmethod
-    def _normalize_name(cls, name: str) -> str:
-        """Normalize names to contain only alphanumerics, _ and -."""
-        return re.sub(r"[^\w-]", "_", name)
 
 
 class SingletonSnapManager:
@@ -79,7 +107,7 @@ class SingletonSnapManager:
         # Use the snap...
 
         # For unregistering
-        manager.unregister("otelcol")
+        manager.unregister_all_for_unit("otelcol")
 
     Raises:
         TimeoutError: If a lock could not be acquired within the specified timeout.
@@ -94,29 +122,43 @@ class SingletonSnapManager:
         Args:
             unit_name: Identifier for the current unit
         """
-        self.unit_name = unit_name
+        self.unit_name = normalize_unit_name(unit_name)
         self._ensure_lock_dir_exists()
 
     @classmethod
     def _ensure_lock_dir_exists(cls) -> None:
         """Ensure the lock directory exists with correct permissions."""
-        try:
-            os.makedirs(cls.LOCK_DIR, exist_ok=True)
-            os.chown(cls.LOCK_DIR, os.geteuid(), os.getegid())
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
+        os.makedirs(cls.LOCK_DIR, exist_ok=True)
+        os.chown(cls.LOCK_DIR, os.geteuid(), os.getegid())
 
-    def register(self, snap_name: str, snap_revision: int) -> None:
-        """Register current unit as using the specified snap and revision.
+    def _remove_unit_lockfiles(self, snap_name: str, exclude_revision: Optional[int] = None) -> None:
+        """Remove lockfiles for this unit and snap.
 
         Args:
             snap_name: Name of the snap.
-            snap_revision: Optional revision to put in the lock file. Defaults to an empty string.
+            exclude_revision: If given, lockfiles with this revision are kept.
+        """
+        for reg in _get_registrations(self.LOCK_DIR, snap_name):
+            if reg.unit_name == self.unit_name and reg.snap_revision != exclude_revision:
+                try:
+                    os.remove(self.LOCK_DIR / reg.filename)
+                except FileNotFoundError:
+                    pass
+
+    def register(self, snap_name: str, snap_revision: int) -> None:
+        """Register current unit as using the specified snap revision.
+
+        If this unit was previously registered for the same snap with a different
+        revision, the old registration is automatically replaced.
+
+        Args:
+            snap_name: Name of the snap.
+            snap_revision: Revision to register.
 
         Raises:
             OSError: if there is an I/O related error creating the lock file.
         """
+        self._remove_unit_lockfiles(snap_name, exclude_revision=snap_revision)
         registration_file = SnapRegistrationFile(
             unit_name=self.unit_name,
             snap_name=snap_name,
@@ -125,18 +167,19 @@ class SingletonSnapManager:
         with open(self.LOCK_DIR.joinpath(registration_file.filename), "w") as f:
             f.write("")
 
-    def unregister(self, snap_name: str, snap_revision: int) -> None:
-        """Unregister current unit from using the specified snap.
+    def unregister_all_for_unit(self, snap_name: str) -> None:
+        """Remove all lockfiles for this unit and snap, regardless of revision.
+
+        Safe to call even if no lockfiles exist. Use during charm removal to ensure
+        cleanup regardless of which revision was last registered.
+
+        Args:
+            snap_name: Name of the snap.
 
         Raises:
-            OSError: if there is an I/O related error removing the lock file.
+            OSError: if there is an I/O related error removing a lock file.
         """
-        registration_file = SnapRegistrationFile(
-            unit_name=self.unit_name,
-            snap_name=snap_name,
-            snap_revision=snap_revision,
-        )
-        os.remove(self.LOCK_DIR.joinpath(registration_file.filename))
+        self._remove_unit_lockfiles(snap_name)
 
     @classmethod
     def get_revisions(cls, snap_name: str) -> Set[int]:
@@ -146,24 +189,20 @@ class SingletonSnapManager:
             snap_name: Name of the snap.
 
         Returns:
-            List of revision integers registered by units for this snap.
+            Set of revision integers registered by units for this snap.
 
         Raises:
             OSError: If there's an error accessing the lock directory or files.
         """
         cls._ensure_lock_dir_exists()
-        revisions = set()
-        for filename in os.listdir(cls.LOCK_DIR):
-            registration_file = SnapRegistrationFile.from_filename(filename)
-            if registration_file.snap_name == snap_name:
-                path = cls.LOCK_DIR.joinpath(filename)
-                if os.path.exists(path):
-                    revisions.add(registration_file.snap_revision)
-        return revisions
+        return {
+            reg.snap_revision
+            for reg in _get_registrations(cls.LOCK_DIR, snap_name)
+        }
 
     @classmethod
     def get_units(cls, snap_name: str) -> Set[str]:
-        """Get all units currently registered for a snap (atomic with directory lock).
+        """Get all units currently registered for a snap.
 
         This method is primarily useful for debugging purposes. In most scenarios, you
         do not need to call this directly. Instead, use
@@ -179,15 +218,8 @@ class SingletonSnapManager:
         Raises:
             OSError: If there's an error accessing the lock directory
         """
-        units = set()
         cls._ensure_lock_dir_exists()
-
-        for filename in os.listdir(cls.LOCK_DIR):
-            registration_file = SnapRegistrationFile.from_filename(filename)
-            if registration_file.snap_name == snap_name:
-                units.add(registration_file.unit_name)
-
-        return units
+        return {reg.unit_name for reg in _get_registrations(cls.LOCK_DIR, snap_name)}
 
     def is_used_by_other_units(self, snap_name: str) -> bool:
         """Check if the specified snap is being used by other units."""

--- a/src/singleton_snap.py
+++ b/src/singleton_snap.py
@@ -48,7 +48,7 @@ class SnapRegistrationFile:
     Example: LCK..opentelemetry-collector--rev10__otelcol_0
 
     Attributes:
-        unit_name: Normalized name of the unit registering the snap (slashes replaced with underscores)
+        unit_name: Name of the unit registering the snap (slashes will be replaced with underscores)
         snap_name: Name of the snap being registered
         snap_revision: Revision of the snap being registered
     """

--- a/tests/integration/test_removal_hooks.py
+++ b/tests/integration/test_removal_hooks.py
@@ -8,7 +8,7 @@ import pathlib
 import jubilant
 
 from constants import CONFIG_FOLDER
-from singleton_snap import SnapRegistrationFile
+from singleton_snap import normalize_unit_name
 import os
 
 from helpers import PATH_EXCLUDE, get_snap_service_status, get_receiver_config, get_hostname
@@ -43,7 +43,7 @@ def test_deploy(juju: jubilant.Juju, charm: str):
     assert get_snap_service_status(juju, "0") == "active"
 
     # AND the name of the OTLP receiver defined in the config file should include the machine hostname
-    config_filename = f"{SnapRegistrationFile._normalize_name('otelcol/0')}.yaml"
+    config_filename = f"{normalize_unit_name('otelcol/0')}.yaml"
     assert get_receiver_config(juju, "ubuntu/0", OTLP_RECEIVER_NAME, os.path.join(CONFIG_FOLDER, config_filename)) == f"otlp/{get_hostname(juju, '0')}"
 
 def test_remove_one_subordinate_one_machine(juju: jubilant.Juju):
@@ -89,7 +89,7 @@ def test_remove_two_subordinates_one_machine(juju: jubilant.Juju):
     assert get_snap_service_status(juju, "0") == "active"
 
     # AND the configs for both units should have an OTLP receiver which includes the machine hostname
-    config_filename = f"{SnapRegistrationFile._normalize_name('otelcol/2')}.yaml"
+    config_filename = f"{normalize_unit_name('otelcol/2')}.yaml"
     assert get_receiver_config(juju, "ubuntu/0", OTLP_RECEIVER_NAME, os.path.join(CONFIG_FOLDER, config_filename)) == f"otlp/{get_hostname(juju, '0')}"
 
 
@@ -115,7 +115,7 @@ def test_remove_two_subordinates_one_machine(juju: jubilant.Juju):
     assert juju.status().get_units("otelcol").keys() == {"otelcol/1"}
 
     # AND the otelcol config file for the second otelcol unit is now removed from disk
-    config_filename = f"{SnapRegistrationFile._normalize_name('otelcol/2')}.yaml"
+    config_filename = f"{normalize_unit_name('otelcol/2')}.yaml"
     otelcol_config = juju.ssh(
         "ubuntu/0",
         command=f'test -e {os.path.join(CONFIG_FOLDER, config_filename)} || echo "does not exist"',
@@ -146,7 +146,7 @@ def test_remove_two_subordinate_two_machines(juju: jubilant.Juju):
 
     # AND the configs for both units should have an OTLP receiver which includes the machine hostname
     # otelcol/4 is related to ubuntu/2 which is on machine 1
-    config_filename = f"{SnapRegistrationFile._normalize_name('otelcol/4')}.yaml"
+    config_filename = f"{normalize_unit_name('otelcol/4')}.yaml"
     assert get_receiver_config(juju, "ubuntu/2", OTLP_RECEIVER_NAME, os.path.join(CONFIG_FOLDER, config_filename)) == f"otlp/{get_hostname(juju, '2')}"
 
     # WHEN the relation is removed

--- a/tests/integration/test_snap_refresh.py
+++ b/tests/integration/test_snap_refresh.py
@@ -1,13 +1,14 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Regression test: charm refresh correctly updates snaps and lockfiles.
+"""Integration tests for snap refresh behaviour.
 
-This test verifies the fix for the bug where `juju refresh` failed to update
-the installed snaps. The root cause was that charm.py checked for
-event() == "upgrade" instead of the correct "upgrade-charm", so _install_snaps()
-was never called during a charm refresh. The result was a BlockedStatus with
-"Mismatching snap revisions" on subsequent refreshes.
+Test progression:
+- GIVEN the charm deployed at an old revision with its snaps and lockfiles in place
+- WHEN the charm is refreshed to a locally built version
+- THEN the managed snaps are updated to the new revisions
+- AND no unit is blocked with "Mismatching snap revisions"
+- AND each lockfile revision matches the installed snap revision
 """
 
 import subprocess

--- a/tests/integration/test_snap_refresh.py
+++ b/tests/integration/test_snap_refresh.py
@@ -19,16 +19,14 @@ import pytest
 from pytest_jubilant import pack
 
 from helpers import PATH_EXCLUDE
-from singleton_snap import SnapRegistrationFile
 
-LOCK_DIR = "/opt/singleton_snaps"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Old charm revision to deploy initially, before refreshing to the current build.
 OLD_CHARM_REVISION = 149
 OLD_CHARM_CHANNEL = "2/stable"
 
-# Snaps managed by this charm whose lockfiles we verify.
+# Snaps managed by this charm.
 MANAGED_SNAPS = ("node-exporter", "opentelemetry-collector")
 
 
@@ -47,26 +45,8 @@ def refreshed_charm() -> str:
     raise subprocess.CalledProcessError(1, "charmcraft pack")
 
 
-def _get_lockfile_revision(juju: jubilant.Juju, snap_name: str) -> int | None:
-    """Return the snap revision recorded in the lockfile for snap_name, or None if absent."""
-    raw = juju.ssh("ubuntu/0", command=f"ls {LOCK_DIR} 2>/dev/null || true").strip()
-    for filename in raw.split():
-        try:
-            reg = SnapRegistrationFile.from_filename(filename)
-        except (ValueError, IndexError):
-            continue
-        if reg.snap_name == snap_name:
-            return reg.snap_revision
-    return None
-
-
-def _get_all_lockfiles(juju: jubilant.Juju) -> str:
-    """Return the contents of the singleton snap lock directory for diagnostics."""
-    return juju.ssh("ubuntu/0", command=f"ls -1 {LOCK_DIR} 2>/dev/null || echo '(empty)'")
-
-
 def _get_installed_snap_revision(juju: jubilant.Juju, snap_name: str, unit: str) -> int:
-    """Return the revision of the currently installed snap on ubuntu/0.
+    """Return the revision of the currently installed snap.
 
     Parses the output of `snap list <snap_name>`:
       Name           Version  Rev   Tracking  Publisher  Notes
@@ -103,30 +83,10 @@ def test_deploy_old_charm_revision(juju: jubilant.Juju):
     )
 
 
-def test_lockfile_matches_installed_snap_before_refresh(juju: jubilant.Juju):
-    """Check: the lockfile revision must match the installed snap revision after deploy."""
-    # GIVEN otelcol deployed at the old charm revision
-    # WHEN we inspect the singleton snap lockfiles and the installed snap revisions
-    for snap_name in MANAGED_SNAPS:
-        lockfile_rev = _get_lockfile_revision(juju, snap_name)
-        installed_rev = _get_installed_snap_revision(juju, snap_name, "ubuntu/0")
-
-        # THEN each lockfile exists and its revision matches the installed snap
-        assert lockfile_rev is not None, f"No {snap_name} lockfile found in {LOCK_DIR}"
-        assert lockfile_rev == installed_rev, (
-            f"{snap_name}: lockfile points to rev{lockfile_rev} "
-            f"but snap rev{installed_rev} is installed"
-        )
-
-
 def test_refresh_to_current_charm(juju: jubilant.Juju, refreshed_charm: str):
-    """Refresh otelcol to the locally built charm and wait for it to settle.
-
-    After the fix, the upgrade-charm hook correctly calls _install_snaps(),
-    which installs the new snap revision and updates the lockfile.
-    """
-    # GIVEN otelcol running at the old charm revision with its lockfiles in place
-    # WHEN the charm is refreshed to the locally built version (containing the fix)
+    """Refresh otelcol to the locally built charm and wait for it to settle."""
+    # GIVEN otelcol running at the old charm revision
+    # WHEN the charm is refreshed to the locally built version
     juju.refresh("otelcol", path=refreshed_charm)
     # THEN ubuntu stays active and all agents settle to idle (no hook errors)
     juju.wait(
@@ -140,45 +100,26 @@ def test_refresh_to_current_charm(juju: jubilant.Juju, refreshed_charm: str):
     )
 
 
-def test_lockfile_matches_installed_snap_after_refresh(juju: jubilant.Juju):
-    """After refresh, lockfiles and snaps must be consistent and the charm must not be blocked.
+def test_snaps_updated_after_refresh(juju: jubilant.Juju):
+    """After refresh, the charm must not be blocked with snap revision mismatches.
 
-    PRIMARY regression check: otelcol units must not report "Mismatching snap revisions".
-    Before the fix, upgrade-charm never called _install_snaps(), so the old lockfile
-    (rev X) remained on disk while the new charm tried to register rev Y, triggering
-    that blocked message on every subsequent hook.
-
-    SECONDARY check: each lockfile revision must equal the installed snap revision,
-    confirming the charm registered and installed consistently.
+    Verifies that upgrade-charm correctly calls _install_snaps().
     """
     # GIVEN otelcol has been refreshed to the locally built charm
-    # WHEN we inspect the unit workload status and the singleton snap lockfiles
+    # WHEN we inspect the unit workload status
     status = juju.status()
-    lockfiles = _get_all_lockfiles(juju)
 
-    # THEN no otelcol unit reports "Mismatching snap revisions" (primary regression check)
+    # THEN no otelcol unit reports "Mismatching snap revisions"
     for unit_name, unit in status.apps["otelcol"].units.items():
         msg = unit.workload_status.message
         assert "Mismatching snap revisions" not in msg, (
-            f"After refresh, {unit_name!r} is blocked: {msg!r}\n"
-            f"This indicates upgrade-charm did not call _install_snaps().\n"
-            f"Lock dir contents:\n{lockfiles}"
+            f"After refresh, {unit_name!r} is blocked: {msg!r}"
         )
 
-    # AND each lockfile revision matches the installed snap revision
+    # AND all managed snaps are installed
     for snap_name in MANAGED_SNAPS:
-        lockfile_rev = _get_lockfile_revision(juju, snap_name)
         installed_rev = _get_installed_snap_revision(juju, snap_name, "ubuntu/0")
-
-        assert lockfile_rev is not None, (
-            f"No {snap_name} lockfile found in {LOCK_DIR} after refresh.\n"
-            f"Lock dir contents:\n{lockfiles}"
-        )
-        assert lockfile_rev == installed_rev, (
-            f"After refresh: {snap_name} lockfile at rev{lockfile_rev} "
-            f"but snap rev{installed_rev} is installed.\n"
-            f"Lock dir contents:\n{lockfiles}"
-        )
+        assert installed_rev > 0, f"{snap_name} is not installed after refresh"
 
     # AND ubuntu remains active and idle
     assert jubilant.all_active(status, "ubuntu")

--- a/tests/integration/test_snap_refresh.py
+++ b/tests/integration/test_snap_refresh.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Regression test: charm refresh correctly updates snaps and lockfiles.
+
+This test verifies the fix for the bug where `juju refresh` failed to update
+the installed snaps. The root cause was that charm.py checked for
+event() == "upgrade" instead of the correct "upgrade-charm", so _install_snaps()
+was never called during a charm refresh. The result was a BlockedStatus with
+"Mismatching snap revisions" on subsequent refreshes.
+"""
+
+import subprocess
+from pathlib import Path
+
+import jubilant
+import pytest
+from pytest_jubilant import pack
+
+from helpers import PATH_EXCLUDE
+from singleton_snap import SnapRegistrationFile
+
+LOCK_DIR = "/opt/singleton_snaps"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Old charm revision to deploy initially, before refreshing to the current build.
+OLD_CHARM_REVISION = 149
+OLD_CHARM_CHANNEL = "2/stable"
+
+# Snaps managed by this charm whose lockfiles we verify.
+MANAGED_SNAPS = ("node-exporter", "opentelemetry-collector")
+
+
+@pytest.fixture(scope="module")
+def refreshed_charm() -> str:
+    """Always pack the charm from current source, bypassing any cached CHARM_PATH.
+
+    This regression test must validate the actual current source code, not a
+    pre-built artifact that may predate the fix.
+    """
+    for _ in range(3):
+        try:
+            return str(pack(REPO_ROOT, platform="ubuntu@22.04:amd64"))
+        except subprocess.CalledProcessError:
+            continue
+    raise subprocess.CalledProcessError(1, "charmcraft pack")
+
+
+def _get_lockfile_revision(juju: jubilant.Juju, snap_name: str) -> int | None:
+    """Return the snap revision recorded in the lockfile for snap_name, or None if absent."""
+    raw = juju.ssh("ubuntu/0", command=f"ls {LOCK_DIR} 2>/dev/null || true").strip()
+    for filename in raw.split():
+        try:
+            reg = SnapRegistrationFile.from_filename(filename)
+        except (ValueError, IndexError):
+            continue
+        if reg.snap_name == snap_name:
+            return reg.snap_revision
+    return None
+
+
+def _get_all_lockfiles(juju: jubilant.Juju) -> str:
+    """Return the contents of the singleton snap lock directory for diagnostics."""
+    return juju.ssh("ubuntu/0", command=f"ls -1 {LOCK_DIR} 2>/dev/null || echo '(empty)'")
+
+
+def _get_installed_snap_revision(juju: jubilant.Juju, snap_name: str, unit: str) -> int:
+    """Return the revision of the currently installed snap on ubuntu/0.
+
+    Parses the output of `snap list <snap_name>`:
+      Name           Version  Rev   Tracking  Publisher  Notes
+      node-exporter  1.9.0    1904  ...
+    """
+    output = juju.ssh(unit, command=f"snap list {snap_name} --unicode=never")
+    parts = output.strip().splitlines()[1].split()
+    return int(parts[2])
+
+
+def test_deploy_old_charm_revision(juju: jubilant.Juju):
+    """Deploy ubuntu and otelcol at an old charm revision to establish a baseline."""
+    # GIVEN a fresh Juju model
+    # WHEN ubuntu and otelcol (old revision) are deployed and integrated
+    juju.deploy("ubuntu", channel="latest/stable", base="ubuntu@22.04")
+    juju.deploy(
+        "opentelemetry-collector",
+        app="otelcol",
+        channel=OLD_CHARM_CHANNEL,
+        revision=OLD_CHARM_REVISION,
+        base="ubuntu@22.04",
+        config={"path_exclude": PATH_EXCLUDE},
+    )
+    juju.integrate("otelcol:juju-info", "ubuntu:juju-info")
+    # THEN ubuntu becomes active and all agents settle to idle
+    juju.wait(
+        lambda status: jubilant.all_active(status, "ubuntu"),
+        error=jubilant.any_error,
+        timeout=600,
+    )
+    juju.wait(
+        lambda status: jubilant.all_agents_idle(status, "ubuntu", "otelcol"),
+        timeout=600,
+    )
+
+
+def test_lockfile_matches_installed_snap_before_refresh(juju: jubilant.Juju):
+    """Sanity check: the lockfile revision must match the installed snap revision after deploy."""
+    # GIVEN otelcol deployed at the old charm revision
+    # WHEN we inspect the singleton snap lockfiles and the installed snap revisions
+    for snap_name in MANAGED_SNAPS:
+        lockfile_rev = _get_lockfile_revision(juju, snap_name)
+        installed_rev = _get_installed_snap_revision(juju, snap_name, "ubuntu/0")
+
+        # THEN each lockfile exists and its revision matches the installed snap
+        assert lockfile_rev is not None, f"No {snap_name} lockfile found in {LOCK_DIR}"
+        assert lockfile_rev == installed_rev, (
+            f"{snap_name}: lockfile points to rev{lockfile_rev} "
+            f"but snap rev{installed_rev} is installed"
+        )
+
+
+def test_refresh_to_current_charm(juju: jubilant.Juju, refreshed_charm: str):
+    """Refresh otelcol to the locally built charm and wait for it to settle.
+
+    After the fix, the upgrade-charm hook correctly calls _install_snaps(),
+    which installs the new snap revision and updates the lockfile.
+    """
+    # GIVEN otelcol running at the old charm revision with its lockfiles in place
+    # WHEN the charm is refreshed to the locally built version (containing the fix)
+    juju.refresh("otelcol", path=refreshed_charm)
+    # THEN ubuntu stays active and all agents settle to idle (no hook errors)
+    juju.wait(
+        lambda status: jubilant.all_active(status, "ubuntu"),
+        error=jubilant.any_error,
+        timeout=600,
+    )
+    juju.wait(
+        lambda status: jubilant.all_agents_idle(status, "ubuntu", "otelcol"),
+        timeout=600,
+    )
+
+
+def test_lockfile_matches_installed_snap_after_refresh(juju: jubilant.Juju):
+    """After refresh, lockfiles and snaps must be consistent and the charm must not be blocked.
+
+    PRIMARY regression check: otelcol units must not report "Mismatching snap revisions".
+    Before the fix, upgrade-charm never called _install_snaps(), so the old lockfile
+    (rev X) remained on disk while the new charm tried to register rev Y, triggering
+    that blocked message on every subsequent hook.
+
+    SECONDARY check: each lockfile revision must equal the installed snap revision,
+    confirming the charm registered and installed consistently.
+    """
+    # GIVEN otelcol has been refreshed to the locally built charm
+    # WHEN we inspect the unit workload status and the singleton snap lockfiles
+    status = juju.status()
+    lockfiles = _get_all_lockfiles(juju)
+
+    # THEN no otelcol unit reports "Mismatching snap revisions" (primary regression check)
+    for unit_name, unit in status.apps["otelcol"].units.items():
+        msg = unit.workload_status.message
+        assert "Mismatching snap revisions" not in msg, (
+            f"After refresh, {unit_name!r} is blocked: {msg!r}\n"
+            f"This indicates upgrade-charm did not call _install_snaps().\n"
+            f"Lock dir contents:\n{lockfiles}"
+        )
+
+    # AND each lockfile revision matches the installed snap revision
+    for snap_name in MANAGED_SNAPS:
+        lockfile_rev = _get_lockfile_revision(juju, snap_name)
+        installed_rev = _get_installed_snap_revision(juju, snap_name, "ubuntu/0")
+
+        assert lockfile_rev is not None, (
+            f"No {snap_name} lockfile found in {LOCK_DIR} after refresh.\n"
+            f"Lock dir contents:\n{lockfiles}"
+        )
+        assert lockfile_rev == installed_rev, (
+            f"After refresh: {snap_name} lockfile at rev{lockfile_rev} "
+            f"but snap rev{installed_rev} is installed.\n"
+            f"Lock dir contents:\n{lockfiles}"
+        )
+
+    # AND ubuntu remains active and idle
+    assert jubilant.all_active(status, "ubuntu")
+    assert jubilant.all_agents_idle(status, "ubuntu")

--- a/tests/integration/test_snap_refresh.py
+++ b/tests/integration/test_snap_refresh.py
@@ -103,7 +103,7 @@ def test_deploy_old_charm_revision(juju: jubilant.Juju):
 
 
 def test_lockfile_matches_installed_snap_before_refresh(juju: jubilant.Juju):
-    """Sanity check: the lockfile revision must match the installed snap revision after deploy."""
+    """Check: the lockfile revision must match the installed snap revision after deploy."""
     # GIVEN otelcol deployed at the old charm revision
     # WHEN we inspect the singleton snap lockfiles and the installed snap revisions
     for snap_name in MANAGED_SNAPS:

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -6,11 +6,11 @@ from pathlib import Path
 
 from charmlibs.pathops import LocalPath
 
-from singleton_snap import SnapRegistrationFile
+from singleton_snap import normalize_unit_name
 
 
 def get_otelcol_config_file(unit_name: str, config_folder:str) -> dict:
-    config_filename = f"{SnapRegistrationFile._normalize_name(unit_name)}.yaml"
+    config_filename = f"{normalize_unit_name(unit_name)}.yaml"
     config_path = LocalPath(Path(config_folder)/config_filename)
     assert config_path.exists(), "file does not exist"
     cfg = yaml.safe_load(config_path.read_text())

--- a/tests/unit/test_charm_lifecycle.py
+++ b/tests/unit/test_charm_lifecycle.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Regression tests for charm lifecycle hooks (install, upgrade-charm, remove)."""
+
+from unittest.mock import patch
+
+from ops.testing import State
+
+from charm import OpenTelemetryCollectorCharm
+
+
+def test_install_snaps_called_on_upgrade_charm(ctx):
+    """Regression: _install_snaps must be called on upgrade-charm, not skipped.
+
+    Before the fix, the code checked for event() == "upgrade" which is not a
+    valid Juju hook name (the correct name is "upgrade-charm"). This caused
+    snaps to never be updated on charm refresh, leaving stale lockfiles pointing
+    to old revisions and blocking the charm with a "Mismatching snap revisions" error.
+    """
+    with (
+        patch("charm.event", return_value="upgrade-charm"),
+        patch.object(OpenTelemetryCollectorCharm, "_install_snaps") as mock_install,
+    ):
+        ctx.run(ctx.on.upgrade_charm(), State())
+    mock_install.assert_called_once()
+
+
+def test_install_snaps_called_on_install(ctx):
+    """Sanity check: _install_snaps must be called on the install hook."""
+    with (
+        patch("charm.event", return_value="install"),
+        patch.object(OpenTelemetryCollectorCharm, "_install_snaps") as mock_install,
+    ):
+        ctx.run(ctx.on.install(), State())
+    mock_install.assert_called_once()
+
+
+def test_install_snaps_not_called_on_other_hooks(ctx):
+    """_install_snaps must NOT be called on regular hooks like update-status."""
+    with (
+        patch("charm.event", return_value="update-status"),
+        patch.object(OpenTelemetryCollectorCharm, "_install_snaps") as mock_install,
+    ):
+        ctx.run(ctx.on.update_status(), State())
+    mock_install.assert_not_called()

--- a/tests/unit/test_charm_lifecycle.py
+++ b/tests/unit/test_charm_lifecycle.py
@@ -11,13 +11,7 @@ from charm import OpenTelemetryCollectorCharm
 
 
 def test_install_snaps_called_on_upgrade_charm(ctx):
-    """Regression: _install_snaps must be called on upgrade-charm, not skipped.
-
-    Before the fix, the code checked for event() == "upgrade" which is not a
-    valid Juju hook name (the correct name is "upgrade-charm"). This caused
-    snaps to never be updated on charm refresh, leaving stale lockfiles pointing
-    to old revisions and blocking the charm with a "Mismatching snap revisions" error.
-    """
+    """_install_snaps is called on upgrade-charm."""
     with (
         patch("charm.event", return_value="upgrade-charm"),
         patch.object(OpenTelemetryCollectorCharm, "_install_snaps") as mock_install,

--- a/tests/unit/test_charm_lifecycle.py
+++ b/tests/unit/test_charm_lifecycle.py
@@ -27,7 +27,7 @@ def test_install_snaps_called_on_upgrade_charm(ctx):
 
 
 def test_install_snaps_called_on_install(ctx):
-    """Sanity check: _install_snaps must be called on the install hook."""
+    """Check: _install_snaps must be called on the install hook."""
     with (
         patch("charm.event", return_value="install"),
         patch.object(OpenTelemetryCollectorCharm, "_install_snaps") as mock_install,

--- a/tests/unit/test_singleton_snap.py
+++ b/tests/unit/test_singleton_snap.py
@@ -116,6 +116,19 @@ def test_is_used_by_other_units_with_juju_style_names():
     assert manager_b.is_used_by_other_units(snap_name)
 
 
+def test_is_used_by_other_units_ignores_revision():
+    snap_name = "node-exporter"
+    # GIVEN two units registered with different revisions
+    manager_a = SingletonSnapManager("otelcol/2")
+    manager_b = SingletonSnapManager("otelcol/3")
+    manager_a.register(snap_name, snap_revision=1904)
+    manager_b.register(snap_name, snap_revision=2154)
+    # THEN is_used_by_other_units returns True regardless of revision mismatch
+    # (it only checks whether another unit is registered, not whether revisions match)
+    assert manager_a.is_used_by_other_units(snap_name)
+    assert manager_b.is_used_by_other_units(snap_name)
+
+
 def test_unregister_all_for_unit_removes_all_revisions(lock_dir):
     snap_name = "node-exporter"
     manager = SingletonSnapManager("unit-0")

--- a/tests/unit/test_singleton_snap.py
+++ b/tests/unit/test_singleton_snap.py
@@ -167,3 +167,18 @@ def test_get_units_skips_malformed_files(lock_dir):
     (lock_dir / "LCK..opentelemetry-collector--rev1__unit-0").touch()
     # THEN get_units skips the malformed file and returns only the valid unit
     assert SingletonSnapManager.get_units(snap_name) == {"unit-0"}
+
+
+def test_register_lockfile_revision_matches_registered_revision(lock_dir):
+    snap_name = "node-exporter"
+    manager = SingletonSnapManager("otelcol/0")
+    # GIVEN a unit registered with an old revision (simulating pre-refresh state)
+    manager.register(snap_name, snap_revision=1904)
+    # WHEN the charm refreshes and registers a new revision
+    manager.register(snap_name, snap_revision=2154)
+    # THEN exactly one lockfile exists for this unit and snap
+    lockfiles = list(lock_dir.glob(f"LCK..{snap_name}*otelcol_0"))
+    assert len(lockfiles) == 1
+    # AND that lockfile encodes the new revision
+    reg = SnapRegistrationFile.from_filename(lockfiles[0].name)
+    assert reg.snap_revision == 2154

--- a/tests/unit/test_singleton_snap.py
+++ b/tests/unit/test_singleton_snap.py
@@ -1,5 +1,5 @@
 import pytest
-from src.singleton_snap import SingletonSnapManager
+from src.singleton_snap import SingletonSnapManager, SnapRegistrationFile
 
 
 @pytest.fixture(autouse=True)
@@ -20,7 +20,7 @@ def test_register_unregister():
     # THEN the registration file can be retrieved
     assert unit_name in manager.get_units(snap_name)
     # AND WHEN it unregisters the snap
-    manager.unregister(snap_name, snap_revision=1)
+    manager.unregister_all_for_unit(snap_name)
     # THEN the registration file is gone
     assert unit_name not in manager.get_units(snap_name)
 
@@ -41,21 +41,10 @@ def test_register_unregister_multiple_units():
     assert unit_one in manager_two.get_units(snap_name)
     assert unit_two in manager_two.get_units(snap_name)
     # AND WHEN one unregisters the snap
-    manager_one.unregister(snap_name, snap_revision=1)
+    manager_one.unregister_all_for_unit(snap_name)
     # THEN its registration file is gone for both managers
     assert unit_one not in manager_one.get_units(snap_name)
     assert unit_one not in manager_two.get_units(snap_name)
-
-
-def test_unregister_without_register():
-    unit_name = "unit-0"
-    snap_name = "opentelemetry-collector"
-    # GIVEN a SingletonSnapManager
-    manager = SingletonSnapManager(unit_name)
-    # WHEN it tries to unregister a non-registered snap
-    # THEN it raises a FileNotFoundError
-    with pytest.raises(FileNotFoundError):
-        manager.unregister(snap_name, snap_revision=1)
 
 
 def test_get_revisions():
@@ -69,7 +58,7 @@ def test_get_revisions():
     # THEN get_revisions displays all the registered revisions
     assert manager_one.get_revisions(snap_name) == {1, 2}
     # AND WHEN one registration is removed
-    manager_one.unregister(snap_name, snap_revision=1)
+    manager_one.unregister_all_for_unit(snap_name)
     # THEN only the other revision is left
     assert manager_two.get_revisions(snap_name) == {2}
 
@@ -84,3 +73,97 @@ def test_get_revisions_duplicated():
     manager_two.register(snap_name, snap_revision=1)
     # THEN get_revisions displays all the registered revisions
     assert manager_one.get_revisions(snap_name) == {1}
+
+
+def test_register_replaces_stale_revision():
+    snap_name = "opentelemetry-collector"
+    # GIVEN a unit with a Juju-style name (containing a slash) registered with an old revision
+    manager = SingletonSnapManager("otelcol/2")
+    manager.register(snap_name, snap_revision=1904)
+    assert manager.get_revisions(snap_name) == {1904}
+    # WHEN it registers a new revision
+    manager.register(snap_name, snap_revision=2154)
+    # THEN only the new revision remains (old lockfile was cleaned up)
+    assert manager.get_revisions(snap_name) == {2154}
+
+
+def test_register_does_not_affect_other_units():
+    snap_name = "opentelemetry-collector"
+    manager_one = SingletonSnapManager("unit-0")
+    manager_two = SingletonSnapManager("unit-1")
+    # GIVEN two units each registered with different old revisions
+    manager_one.register(snap_name, snap_revision=1)
+    manager_two.register(snap_name, snap_revision=2)
+    # WHEN unit-0 upgrades its revision
+    manager_one.register(snap_name, snap_revision=3)
+    # THEN unit-1's lockfile is untouched
+    assert manager_one.get_revisions(snap_name) == {3, 2}
+
+
+def test_is_used_by_other_units_with_juju_style_names():
+    snap_name = "node-exporter"
+    # GIVEN units with Juju-style names (slash in unit name)
+    manager_a = SingletonSnapManager("otelcol/2")
+    manager_b = SingletonSnapManager("otelcol/3")
+    # WHEN only this unit is registered
+    manager_a.register(snap_name, snap_revision=2154)
+    # THEN is_used_by_other_units returns False
+    assert not manager_a.is_used_by_other_units(snap_name)
+    # WHEN another unit also registers
+    manager_b.register(snap_name, snap_revision=2154)
+    # THEN both see the other as using the snap
+    assert manager_a.is_used_by_other_units(snap_name)
+    assert manager_b.is_used_by_other_units(snap_name)
+
+
+def test_unregister_all_for_unit_removes_all_revisions(lock_dir):
+    snap_name = "node-exporter"
+    manager = SingletonSnapManager("unit-0")
+    # GIVEN a current lockfile plus a manually-created stale one (simulating pre-fix state)
+    manager.register(snap_name, snap_revision=2154)
+    stale = SnapRegistrationFile(unit_name="unit-0", snap_name=snap_name, snap_revision=1904)
+    (lock_dir / stale.filename).touch()
+    assert manager.get_revisions(snap_name) == {1904, 2154}
+    # WHEN unregister_all_for_unit is called
+    manager.unregister_all_for_unit(snap_name)
+    # THEN all lockfiles for this unit are gone
+    assert manager.get_revisions(snap_name) == set()
+
+
+def test_unregister_all_for_unit_does_not_affect_other_units():
+    snap_name = "node-exporter"
+    manager_a = SingletonSnapManager("unit-0")
+    manager_b = SingletonSnapManager("unit-1")
+    manager_a.register(snap_name, snap_revision=1)
+    manager_b.register(snap_name, snap_revision=1)
+    # WHEN unit-0 unregisters all
+    manager_a.unregister_all_for_unit(snap_name)
+    # THEN unit-1's lockfile is untouched
+    assert manager_b.get_revisions(snap_name) == {1}
+    assert "unit-1" in manager_b.get_units(snap_name)
+
+
+def test_unregister_all_for_unit_no_files():
+    snap_name = "node-exporter"
+    manager = SingletonSnapManager("unit-0")
+    # GIVEN no lockfiles exist
+    # THEN unregister_all_for_unit does not raise
+    manager.unregister_all_for_unit(snap_name)
+
+
+def test_get_revisions_skips_malformed_files(lock_dir):
+    snap_name = "opentelemetry-collector"
+    # GIVEN a malformed file alongside a valid lockfile
+    (lock_dir / "malformed_file").touch()
+    (lock_dir / "LCK..opentelemetry-collector--rev1__unit-0").touch()
+    # THEN get_revisions skips the malformed file and returns the valid revision
+    assert SingletonSnapManager.get_revisions(snap_name) == {1}
+
+
+def test_get_units_skips_malformed_files(lock_dir):
+    snap_name = "opentelemetry-collector"
+    # GIVEN a malformed file alongside a valid lockfile
+    (lock_dir / "random_other_file").touch()
+    (lock_dir / "LCK..opentelemetry-collector--rev1__unit-0").touch()
+    # THEN get_units skips the malformed file and returns only the valid unit
+    assert SingletonSnapManager.get_units(snap_name) == {"unit-0"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -700,7 +700,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-jubilant" },
     { name = "ruff" },
-    { name = "sh" },
 ]
 
 [package.metadata]
@@ -723,7 +722,6 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sh" },
-    { name = "sh", marker = "extra == 'dev'" },
     { name = "tenacity" },
     { name = "urllib3" },
 ]


### PR DESCRIPTION
## Issue
 
Fixes #209
 
When running `juju refresh` to switch the charm to a different channel/revision, the managed snaps (`node-exporter`, `opentelemetry-collector`) were not updated. The unit ended up permanently blocked with:
 
> Mismatching snap revisions for node-exporter. The charm requested revX, but a
> different app installed revY.
 
 
## Solution
 
The root cause was a typo in `charm.py`: the hook dispatch check used `"upgrade"` instead of the correct Juju hook name `"upgrade-charm"` (with a hyphen), so  `_install_snaps()` was never called during a charm refresh.
 
Additionally, stale lockfiles from the previous revision were not cleaned up before re-registering, which caused the mismatch error to persist on every subsequent hook.
 
Changes:

- Fixed the hook name check: `"upgrade"` → `"upgrade-charm"`.
- Added `unregister_all_for_unit()` to remove stale lockfiles before re-registering on each install/refresh cycle.
- Several readability improvements to `singleton_snap.py` while tracing the bug: extracted `normalize_unit_name()` as a public module-level function, simplified `from_filename()`, changed `_get_registrations()` to return `List[SnapRegistrationFile]` directly
 
### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.
 
 
## Context
 
This charm uses a file-based singleton registration system (`/opt/singleton_snaps/`) to coordinate snap installations across multiple subordinate units sharing the same machine. Each unit writes a lockfile of the form `LCK..<snap_name>--rev<revision>__<unit_name>` when it registers a snap revision. The "Mismatching snap revisions" error is raised when two lockfiles for the same snap but different revisions are found simultaneously — which is expected when units are on different charm revisions, but must not happen when a single unit refreshes.
 
 
## Testing Instructions
 
### Unit tests

```shell
tox -e unit
```
 
### Integration regression test

```shell
tox -e integration -- tests/integration/test_snap_refresh.py
```
 
The integration test deploys the charm at the old revision (149, `2/stable`), verifies lockfiles match installed snap revisions, refreshes to a locally packed build of this branch, and asserts that no unit reports "Mismatching snap revisions" and that lockfile revisions still match the installed snaps after refresh.
 
 
 ## Upgrade Notes
 
No special steps required. After refreshing to this revision, the `upgrade-charm` hook will correctly reinstall the snaps and update the lockfiles automatically.