### PR TITLE
fix remote build by adding cryptography build dependencies

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -71,7 +71,14 @@ parts:
   charm:
     source: .
     plugin: uv
-    build-packages: [git]
+    build-packages:
+      - git
+      # There's no cryptography wheel for s390x, so need to build from source
+      - to s390x:
+        - libffi-dev
+        - libssl-dev
+        - libyaml-dev
+        - pkg-config
     build-snaps: [astral-uv]
     override-build: |
       craftctl default


### PR DESCRIPTION
In the previous PR adding s390x support, apparently we were able to merge even though the remote-build did not work. We need to add the build dependencies for cryptography when building for s390x.