### PR TITLE
fix: test_tracing itest

### DIFF
--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -35,6 +35,6 @@ def test_deploy(juju: jubilant.Juju, charm_22_04: str):
 
 
 def test_traces_are_scraped(juju: jubilant.Juju):
-    grep_filters = ["ScopeTraces", "postgresql-charm"]
+    grep_filters = ["ResourceTraces", "postgresql"]
     result = is_pattern_in_debug_logs(juju, grep_filters)
     assert result


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The current `test_tracing` integration test keeps failing on the step where it needs to assert that it can find a log line such which includes both `ScopeTraces` and `postgresql-charm`. However, this check never succeeds. If you set up the test scenario manually and look at the pebble logs, you'll notice that `ScopeTraces` is always one line below the trace log for `postgres` and that the  `grep` filter of `postgresql-charm` doesn't exist:
```
ResourceTraces #0 telemetry.sdk.language=python telemetry.sdk.name=opentelemetry telemetry.sdk.version=1.40.0 service.namespace=5fb2855e-e95e-4a07-88da-6b690910348b service.namespace.name=test service.name=pg service.instance.id=0 charm=postgresql charm_type=PostgresqlOperatorCharm juju_model=test juju_model_uuid=5fb2855e-e95e-4a07-88da-6b690910348b juju_application=pg juju_unit=pg/0
2026-05-05T18:21:20Z opentelemetry-collector.opentelemetry-collector[32808]: ScopeTraces #0 ops@3.7.0
```
This is why `sudo snap logs opentelemetry-collector -n=all | grep ScopeTraces | grep postgresql-charm` consistently fails.

The solution is to assert that there is line that includes the strings `ResourceTraces` and `postgresql`.

## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
