### PR TITLE
feat: render separate configs for multiple streams

### DIFF
--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -1,12 +1,14 @@
 """Grafana Cloud Integrator Configuration Requirer."""
 
+from __future__ import annotations
+
 import logging
 
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "e6f580481c1b4388aa4d2cdf412a47fa"
 LIBAPI = 0
-LIBPATCH = 8
+LIBPATCH = 11
 
 DEFAULT_RELATION_NAME = "grafana-cloud-config"
 
@@ -16,7 +18,7 @@ logger = logging.getLogger(__name__)
 class Credentials:
     """Credentials for the remote endpoints."""
 
-    def __init__(self, username, password):
+    def __init__(self, username: str, password: str):
         self.username = username
         self.password = password
 
@@ -24,19 +26,13 @@ class Credentials:
 class CloudConfigAvailableEvent(EventBase):
     """Event emitted when cloud config is available."""
 
-    def __init__(self, handle):
-        super().__init__(handle)
-
 
 class CloudConfigRevokedEvent(EventBase):
-    """Event emitted when cloud config is available."""
-
-    def __init__(self, handle):
-        super().__init__(handle)
+    """Event emitted when cloud config is revoked."""
 
 
 class GrafanaCloudConfigEvents(ObjectEvents):
-    """Event descriptor for events raised by `GrafanaCloudConfigRequirer`."""
+    """Event descriptor for `GrafanaCloudConfigRequirer`."""
 
     cloud_config_available = EventSource(CloudConfigAvailableEvent)
     cloud_config_revoked = EventSource(CloudConfigRevokedEvent)
@@ -45,9 +41,9 @@ class GrafanaCloudConfigEvents(ObjectEvents):
 class GrafanaCloudConfigRequirer(Object):
     """Requirer side of the Grafana Cloud Config relation."""
 
-    on = GrafanaCloudConfigEvents()  # pyright: ignore
+    on = GrafanaCloudConfigEvents()  # pyright: ignore[reportAssignmentType]
 
-    def __init__(self, charm, relation_name=DEFAULT_RELATION_NAME):
+    def __init__(self, charm, relation_name: str = DEFAULT_RELATION_NAME):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
@@ -58,34 +54,40 @@ class GrafanaCloudConfigRequirer(Object):
         for event in self._broken_events:
             self.framework.observe(event, self._on_relation_broken)
 
-    def _on_relation_changed(self, event):
-        self.on.cloud_config_available.emit()  # pyright: ignore
+    def _on_relation_changed(self, _event) -> None:
+        """Emit a change event when relation data changes."""
+        self.on.cloud_config_available.emit()  # pyright: ignore[reportAttributeAccessIssue]
 
-    def _on_relation_broken(self, event):
-        self.on.cloud_config_revoked.emit()  # pyright: ignore
-
-    def _is_not_empty(self, s):
-        return bool(s and not s.isspace())
+    def _on_relation_broken(self, _event) -> None:
+        """Emit a revocation event when the relation is removed."""
+        self.on.cloud_config_revoked.emit()  # pyright: ignore[reportAttributeAccessIssue]
 
     @property
     def _change_events(self):
+        relation_events = self._events
         return [
-            self._events.relation_joined,
-            self._events.relation_changed,
-            self._events.relation_created,
+            relation_events.relation_joined,
+            relation_events.relation_changed,
+            relation_events.relation_created,
         ]
 
     @property
     def _broken_events(self):
-        return [self._events.relation_departed, self._events.relation_broken]
+        relation_events = self._events
+        return [relation_events.relation_departed, relation_events.relation_broken]
 
     @property
     def _events(self):
         return self._charm.on[self._relation_name]
 
+    @staticmethod
+    def _is_not_empty(value: str) -> bool:
+        """Return whether a string value is set and non-whitespace."""
+        return bool(value and not value.isspace())
+
     @property
-    def credentials(self):
-        """Return the credentials, if any; otherwise, return None."""
+    def credentials(self) -> Credentials | None:
+        """Return credentials from relation data when both are present."""
         if (username := self._data.get("username", "").strip()) and (
             password := self._data.get("password", "").strip()
         ):
@@ -93,77 +95,104 @@ class GrafanaCloudConfigRequirer(Object):
         return None
 
     @property
-    def loki_ready(self):
-        """Check whether there is a non-empty Loki url in relation data."""
+    def prometheus_credentials(self) -> Credentials | None:
+        """Return Prometheus credentials or fall back to shared credentials."""
+        return self._signal_credentials("prometheus")
+
+    @property
+    def loki_credentials(self) -> Credentials | None:
+        """Return Loki credentials or fall back to shared credentials."""
+        return self._signal_credentials("loki")
+
+    @property
+    def tempo_credentials(self) -> Credentials | None:
+        """Return Tempo credentials or fall back to shared credentials."""
+        return self._signal_credentials("tempo")
+
+    @property
+    def otlp_credentials(self) -> Credentials | None:
+        """Return OTLP credentials or fall back to shared credentials."""
+        return self._signal_credentials("otlp")
+
+    @property
+    def pyroscope_credentials(self) -> Credentials | None:
+        """Return Pyroscope credentials or fall back to shared credentials."""
+        return self._signal_credentials("pyroscope")
+
+    @property
+    def loki_ready(self) -> bool:
+        """Return whether a Loki URL is available."""
         return self._is_not_empty(self.loki_url)
 
     @property
-    def loki_endpoint(self) -> dict:
-        """Return the loki endpoint dict."""
-        if not self.loki_ready:
-            return {}
-
-        endpoint = {}
-        endpoint["url"] = self.loki_url
-        if self.credentials:
-            endpoint["basic_auth"] = {
-                "username": self.credentials.username,
-                "password": self.credentials.password,
-            }
-        return endpoint
-
-    @property
-    def prometheus_ready(self):
-        """Check whether there is a non-empty Prometheus url in relation data."""
+    def prometheus_ready(self) -> bool:
+        """Return whether a Prometheus URL is available."""
         return self._is_not_empty(self.prometheus_url)
 
     @property
-    def tempo_ready(self):
-        """Check whether there is a non-empty Tempo url in relation data."""
+    def tempo_ready(self) -> bool:
+        """Return whether a Tempo URL is available."""
         return self._is_not_empty(self.tempo_url)
 
     @property
-    def tls_ca_ready(self):
-        """Check whether there is a TLS CA in relation data."""
+    def otlp_ready(self) -> bool:
+        """Return whether an OTLP URL is available."""
+        return self._is_not_empty(self.otlp_url)
+
+    @property
+    def pyroscope_ready(self) -> bool:
+        """Return whether a Pyroscope URL is available."""
+        return self._is_not_empty(self.pyroscope_url)
+
+    @property
+    def tls_ca_ready(self) -> bool:
+        """Return whether a TLS CA is available."""
         return self._is_not_empty(self.tls_ca)
 
     @property
-    def prometheus_endpoint(self) -> dict:
-        """Return the prometheus endpoint dict."""
-        if not self.prometheus_ready:
-            return {}
-
-        endpoint = {}
-        endpoint["url"] = self.prometheus_url
-        if self.credentials:
-            endpoint["basic_auth"] = {
-                "username": self.credentials.username,
-                "password": self.credentials.password,
-            }
-        return endpoint
-
-    @property
     def loki_url(self) -> str:
-        """The Loki endpoint from relation data."""
+        """Return the Loki URL from relation data."""
         return self._data.get("loki_url", "")
 
     @property
     def tempo_url(self) -> str:
-        """The Tempo endpoint from relation data."""
+        """Return the Tempo URL from relation data."""
         return self._data.get("tempo_url", "")
 
     @property
+    def otlp_url(self) -> str:
+        """Return the OTLP URL from relation data."""
+        return self._data.get("otlp_url", "")
+
+    @property
     def prometheus_url(self) -> str:
-        """The Prometheus endpoint from relation data."""
+        """Return the Prometheus URL from relation data."""
         return self._data.get("prometheus_url", "")
 
     @property
+    def pyroscope_url(self) -> str:
+        """Return the Pyroscope URL from relation data."""
+        return self._data.get("pyroscope_url", "")
+
+    @property
     def tls_ca(self) -> str:
-        """TLS CA from relation data."""
+        """Return the TLS CA from relation data."""
         return self._data.get("tls-ca", "")
 
     @property
-    def _data(self):
-        for relation in self._charm.model.relations[self._relation_name]:
-            return relation.data[relation.app]
+    def _data(self) -> dict[str, str]:
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            if relation.app is None:
+                continue
+            return dict(relation.data[relation.app])
         return {}
+
+    def _signal_credentials(self, signal_name: str) -> Credentials | None:
+        """Return signal-specific credentials, falling back to shared credentials."""
+        username_key = f"{signal_name}_username"
+        password_key = f"{signal_name}_password"
+        if (username := self._data.get(username_key, "").strip()) and (
+            password := self._data.get(password_key, "").strip()
+        ):
+            return Credentials(username, password)
+        return self.credentials

--- a/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
+++ b/lib/charms/grafana_cloud_integrator/v0/cloud_config_requirer.py
@@ -165,6 +165,5 @@ class GrafanaCloudConfigRequirer(Object):
     @property
     def _data(self):
         for relation in self._charm.model.relations[self._relation_name]:
-            logger.info("%s %s %s", relation, self._relation_name, relation.data[relation.app])
             return relation.data[relation.app]
         return {}

--- a/src/charm.py
+++ b/src/charm.py
@@ -472,10 +472,14 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         # GrafanaCloudIntegrator setup
         cloud_integrator_data = integrations.cloud_integrator(self)
         config_manager.add_cloud_integrator(
-            username=cloud_integrator_data.username,
-            password=cloud_integrator_data.password,
+            prometheus_username=cloud_integrator_data.prometheus_username,
+            prometheus_password=cloud_integrator_data.prometheus_password,
             prometheus_url=cloud_integrator_data.prometheus_url,
+            loki_username=cloud_integrator_data.loki_username,
+            loki_password=cloud_integrator_data.loki_password,
             loki_url=cloud_integrator_data.loki_url,
+            tempo_username=cloud_integrator_data.tempo_username,
+            tempo_password=cloud_integrator_data.tempo_password,
             tempo_url=cloud_integrator_data.tempo_url,
         )
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -492,38 +492,43 @@ class ConfigManager:
 
     def add_cloud_integrator(
         self,
-        username: Optional[str],
-        password: Optional[str],
+        prometheus_username: Optional[str],
+        prometheus_password: Optional[str],
         prometheus_url: Optional[str],
+        loki_username: Optional[str],
+        loki_password: Optional[str],
         loki_url: Optional[str],
+        tempo_username: Optional[str],
+        tempo_password: Optional[str],
         tempo_url: Optional[str],
     ) -> None:
         """Configure forwarding telemetry to the endpoints provided by a cloud-integrator charm.
 
         Args:
-            username: Username for basic authentication (if required)
-            password: Password for basic authentication (if required)
+            prometheus_username: Username for Prometheus basic authentication
+            prometheus_password: Password for Prometheus basic authentication
             prometheus_url: URL for forwarding metrics (e.g., Prometheus remote write)
+            loki_username: Username for Loki basic authentication
+            loki_password: Password for Loki basic authentication
             loki_url: URL for forwarding logs to Loki
+            tempo_username: Username for Tempo basic authentication
+            tempo_password: Password for Tempo basic authentication
             tempo_url: URL for forwarding traces to Tempo
 
         Note:
-            If both username and password are provided, they will be used for
-            basic authentication with all configured endpoints. The TLS settings
-            (including insecure_skip_verify) will be inherited from the ConfigManager.
+            Each configured signal gets its own basic-auth extension so per-signal
+            credentials can be used when provided. The TLS settings inherit from
+            the ConfigManager.
         """
-        exporter_auth_config = {}
-        if username and password:
-            self.config.add_extension(
-                "basicauth/cloud-integrator",
-                {
-                    "client_auth": {
-                        "username": username,
-                        "password": password,
-                    }
-                },
-            )
-            exporter_auth_config = {"auth": {"authenticator": "basicauth/cloud-integrator"}}
+        prometheus_auth_config = self._cloud_integrator_auth_config(
+            "prometheus", prometheus_username, prometheus_password
+        )
+        loki_auth_config = self._cloud_integrator_auth_config(
+            "loki", loki_username, loki_password
+        )
+        tempo_auth_config = self._cloud_integrator_auth_config(
+            "tempo", tempo_username, tempo_password
+        )
         if prometheus_url:
             self.config.add_component(
                 Component.exporter,
@@ -531,7 +536,7 @@ class ConfigManager:
                 {
                     "endpoint": prometheus_url,
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
-                    **exporter_auth_config,
+                    **prometheus_auth_config,
                     **self.prometheus_remotewrite_wal_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],
@@ -545,7 +550,7 @@ class ConfigManager:
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
                     "default_labels_enabled": {"exporter": False, "job": True},
                     "headers": {"Content-Encoding": "snappy"},  # TODO: check if this is needed
-                    **exporter_auth_config,
+                    **loki_auth_config,
                     **self.sending_queue_config,
                 },
                 pipelines=[f"logs/{self._unit_name}"],
@@ -557,11 +562,30 @@ class ConfigManager:
                 {
                     "endpoint": tempo_url,
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
-                    **exporter_auth_config,
+                    **tempo_auth_config,
                     **self.sending_queue_config,
                 },
                 pipelines=[f"traces/{self._unit_name}"],
             )
+
+    def _cloud_integrator_auth_config(
+        self, signal_name: str, username: Optional[str], password: Optional[str]
+    ) -> Dict[str, Any]:
+        """Add and return auth config for a cloud-integrator exporter when creds exist."""
+        if not username or not password:
+            return {}
+
+        extension_name = f"basicauth/cloud-integrator-{signal_name}"
+        self.config.add_extension(
+            extension_name,
+            {
+                "client_auth": {
+                    "username": username,
+                    "password": password,
+                }
+            },
+        )
+        return {"auth": {"authenticator": extension_name}}
 
     def add_custom_processors(self, processors_raw: str) -> None:
         """Add custom processors from Juju configuration.

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -460,10 +460,14 @@ def forward_dashboards(charm: CharmBase):
 class CloudIntegratorData:
     """Wrapper around the data returned by GrafanaCloudIntegrator."""
 
-    username: Optional[str]
-    password: Optional[str]
+    prometheus_username: Optional[str]
+    prometheus_password: Optional[str]
     prometheus_url: Optional[str]
+    loki_username: Optional[str]
+    loki_password: Optional[str]
     loki_url: Optional[str]
+    tempo_username: Optional[str]
+    tempo_password: Optional[str]
     tempo_url: Optional[str]
 
 
@@ -473,18 +477,35 @@ def cloud_integrator(charm: CharmBase) -> CloudIntegratorData:
     # we decided that we should only get certs from receive-ca-cert.
     cloud_integrator = GrafanaCloudConfigRequirer(charm, relation_name="cloud-config")
     charm.__setattr__("cloud_integrator", cloud_integrator)
-    username, password = (
-        (cloud_integrator.credentials.username, cloud_integrator.credentials.password)
-        if cloud_integrator.credentials
+    prometheus_username, prometheus_password = (
+        (
+            cloud_integrator.prometheus_credentials.username,
+            cloud_integrator.prometheus_credentials.password,
+        )
+        if cloud_integrator.prometheus_credentials
+        else (None, None)
+    )
+    loki_username, loki_password = (
+        (cloud_integrator.loki_credentials.username, cloud_integrator.loki_credentials.password)
+        if cloud_integrator.loki_credentials
+        else (None, None)
+    )
+    tempo_username, tempo_password = (
+        (cloud_integrator.tempo_credentials.username, cloud_integrator.tempo_credentials.password)
+        if cloud_integrator.tempo_credentials
         else (None, None)
     )
     return CloudIntegratorData(
-        username=username,
-        password=password,
+        prometheus_username=prometheus_username,
+        prometheus_password=prometheus_password,
         prometheus_url=cloud_integrator.prometheus_url
         if cloud_integrator.prometheus_ready
         else None,
+        loki_username=loki_username,
+        loki_password=loki_password,
         loki_url=cloud_integrator.loki_url if cloud_integrator.loki_ready else None,
+        tempo_username=tempo_username,
+        tempo_password=tempo_password,
         tempo_url=cloud_integrator.tempo_url if cloud_integrator.tempo_ready else None,
     )
 

--- a/tests/unit/test_cloud_config_integration.py
+++ b/tests/unit/test_cloud_config_integration.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Feature: cloud-config signal-specific credentials."""
+
+from ops.testing import Relation, State
+
+from tests.unit.helpers import get_otelcol_config_file
+
+
+def test_cloud_config_relation_uses_signal_specific_credentials(ctx, unit_name, config_folder):
+    """Scenario: cloud-config exporters use distinct credentials for each signal."""
+    cloud_relation = Relation(
+        endpoint="cloud-config",
+        interface="grafana_cloud_config",
+        remote_app_name="grafana-cloud-integrator",
+        remote_app_data={
+            "prometheus_url": "https://prometheus-prod.example/api/prom/push",
+            "prometheus_username": "1076854",
+            "prometheus_password": "prom-token",
+            "loki_url": "https://logs-prod.example/loki/api/v1/push",
+            "loki_username": "639149",
+            "loki_password": "loki-token",
+            "tempo_url": "https://tempo-prod.example/otlp",
+            "tempo_username": "tempo-user",
+            "tempo_password": "tempo-token",
+        },
+    )
+    state_in = State(relations=[cloud_relation])
+
+    # WHEN any event executes the reconciler
+    ctx.run(ctx.on.update_status(), state=state_in)
+
+    # THEN the config file exists and has distinct auth per signal
+    cfg = get_otelcol_config_file(unit_name, config_folder)
+    assert cfg["extensions"]["basicauth/cloud-integrator-prometheus"]["client_auth"] == {
+        "username": "1076854",
+        "password": "prom-token",
+    }
+    assert cfg["extensions"]["basicauth/cloud-integrator-loki"]["client_auth"] == {
+        "username": "639149",
+        "password": "loki-token",
+    }
+    assert cfg["extensions"]["basicauth/cloud-integrator-tempo"]["client_auth"] == {
+        "username": "tempo-user",
+        "password": "tempo-token",
+    }
+    assert cfg["exporters"]["prometheusremotewrite/cloud-config"]["auth"] == {
+        "authenticator": "basicauth/cloud-integrator-prometheus"
+    }
+    assert cfg["exporters"]["loki/cloud-config"]["auth"] == {
+        "authenticator": "basicauth/cloud-integrator-loki"
+    }
+    assert cfg["exporters"]["otlphttp/cloud-config"]["auth"] == {
+        "authenticator": "basicauth/cloud-integrator-tempo"
+    }

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -215,3 +215,44 @@ def test_add_debug_exporters(enabled_pipelines, expected_pipelines):
     ]
     # AND the debug exporter is only attached to the enabled pipelines
     assert expected_pipelines == config_manager.config._config["service"]["pipelines"]
+
+
+def test_add_cloud_integrator_uses_signal_specific_credentials():
+    # GIVEN an empty config
+    config_manager = ConfigManager("otelcol/0", "0", "", "", insecure_skip_verify=True)
+
+    # WHEN cloud-config exporters are added with separate credentials per signal
+    config_manager.add_cloud_integrator(
+        prometheus_username="1076854",
+        prometheus_password="prom-token",
+        prometheus_url="https://prometheus.example/api/prom/push",
+        loki_username="639149",
+        loki_password="loki-token",
+        loki_url="https://logs.example/loki/api/v1/push",
+        tempo_username="tempo-user",
+        tempo_password="tempo-token",
+        tempo_url="https://tempo.example/otlp",
+    )
+
+    # THEN each exporter has its own authenticator extension
+    extensions = config_manager.config._config["extensions"]
+    assert extensions["basicauth/cloud-integrator-prometheus"] == {
+        "client_auth": {"username": "1076854", "password": "prom-token"}
+    }
+    assert extensions["basicauth/cloud-integrator-loki"] == {
+        "client_auth": {"username": "639149", "password": "loki-token"}
+    }
+    assert extensions["basicauth/cloud-integrator-tempo"] == {
+        "client_auth": {"username": "tempo-user", "password": "tempo-token"}
+    }
+
+    exporters = config_manager.config._config["exporters"]
+    assert exporters["prometheusremotewrite/cloud-config"]["auth"] == {
+        "authenticator": "basicauth/cloud-integrator-prometheus"
+    }
+    assert exporters["loki/cloud-config"]["auth"] == {
+        "authenticator": "basicauth/cloud-integrator-loki"
+    }
+    assert exporters["otlphttp/cloud-config"]["auth"] == {
+        "authenticator": "basicauth/cloud-integrator-tempo"
+    }

--- a/tests/unit/test_dashboard_transfer.py
+++ b/tests/unit/test_dashboard_transfer.py
@@ -53,6 +53,6 @@ def test_dashboard_propagation(ctx):
             # THEN each Grafana instance receives otelcol's bundled dashboard and aggregated dashboards
             if "-provider" in rel.endpoint:
                 dashboard_str = rel.local_app_data["dashboards"]
-                assert "file:juju_file:dashboard-0-some-charm-1" in dashboard_str
-                assert "file:juju_file:dashboard-1-some-charm-2" in dashboard_str
+                assert f"file:juju_file:dashboard-0-some-charm-{consumer0.id}" in dashboard_str
+                assert f"file:juju_file:dashboard-1-some-charm-{consumer1.id}" in dashboard_str
                 assert "file:overview-dashboard" in dashboard_str


### PR DESCRIPTION
## Issue

This makes opentelemetry-collector be able to render separate configs for multiple streams: Loki, Prometheus, etc as part of relating to grafana-cloud-integrator.

The old version could not handle multiple credentials, which is needed by grafana cloud.

This feature is needed to be able to use grafana cloud at all with more than a single stream.

## Solution

It picks up per-stream keys from the relation, using the upgraded library introduced here:  [grafana-cloud-integrator - PR #42](https://github.com/canonical/grafana-cloud-integrator/pull/42)

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context

This is targeting functionality provided by the grafana-cloud-integrator charm.

## Testing Instructions

This change was tested against `opentelemetry-collector-operator` `track/2` with a `grafana-cloud-integrator` deployment that includes the behavior from [`canonical/grafana-cloud-integrator#42`](https://github.com/canonical/grafana-cloud-integrator/pull/42): separate credentials per signal.

### Scope

The PR is correct if all of the following are true:

- `opentelemetry-collector` reads signal-specific credentials from the `cloud-config` relation.
- metrics use `prometheus_username/password`
- logs use `loki_username/password`
- traces use `tempo_username/password`
- shared `username/password` still works as a fallback
- rendered collector config uses different `basicauth` entries per signal
- `juju debug-log` no longer prints Grafana Cloud credentials

### Automated verification

From the `opentelemetry-collector-operator` repo:

```bash
tox -e lint
tox -e static
tox -e unit
```

Focused regression coverage added for this work:

```bash
tox -e unit -- tests/unit/test_cloud_config_integration.py
tox -e unit -- tests/unit/test_config_manager.py
```

Expected result:

- all commands pass
- unit coverage includes separate auth assertions for Prometheus, Loki, and OTLP/Tempo paths
- fallback behavior for shared credentials remains green

### Live model validation

This was validated in a live Juju model with assumption:

- the consumed SAAS `grafana-cloud-integrator` is deployed from code containing PR `#42` behavior

Build and deploy the local charm from the `track/2` working tree:

```bash
charmcraft pack
juju deploy ./opentelemetry-collector_ubuntu@24.04-amd64.charm otelcol-track2-test
```

Relate it:

```bash
juju relate otelcol-track2-test grafana-cloud-integrator
juju relate otelcol-track2-test iris:juju-info
```

Wait for the unit to settle, then inspect rendered config:

```bash
juju ssh otelcol-track2-test/0 sudo cat /var/snap/opentelemetry-collector/common/otelcol/config.yaml
```

### Expected rendered config

The generated config should contain distinct authenticators and exporter bindings, for example:

- `basicauth/cloud-integrator-prometheus`
- `basicauth/cloud-integrator-loki`
- `basicauth/cloud-integrator-tempo` or `otlphttp/cloud-config` auth using the tempo-specific credentials path used by the charm

And the exporters should reference the matching authenticator:

- `prometheusremotewrite/cloud-config` -> `basicauth/cloud-integrator-prometheus`
- `loki/cloud-config` -> `basicauth/cloud-integrator-loki`
- traces exporter -> tempo-specific authenticator

In the live validation I observed distinct usernames for Prometheus and Loki, confirming that the relation data was not being collapsed to one shared credential pair.

### Credential leak regression check
Functionally not part of the PR, but the commits also removes a leaked credential from logs while the relation is established or refreshed, juju dumps the complete databag to logs which isn't good. It is removed also here.

```bash
juju debug-log --replay | rg 'grafana|username|password|cloud-config'
```

Expected result:

- hook execution is visible
- Grafana Cloud usernames/passwords are not printed in relation-change logs
- no raw relation databag dump appears in the log stream

### Fallback regression
The old behavior (only one credential) is still in the code for backward compatibility, repeat the relation test with a `grafana-cloud-integrator` instance that only publishes shared:

- `username`
- `password`

Expected result:

- metrics, logs, and traces still configure successfully
- all exporters use the shared credentials when signal-specific keys are absent

### PR note

Tested with a locally built `track/2` charm, related to a `grafana-cloud-integrator` deployment implementing `canonical/grafana-cloud-integrator#42`. 

Verified unit coverage, live rendered config, distinct per-signal auth wiring, shared-credential fallback, and absence of credential leakage in `juju debug-log`.


## Upgrade Notes
Not covered.
