### PR TITLE
fix: avoid redundant node-exporter snap config writes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -128,6 +128,20 @@ def event() -> str:
     """
     return os.environ.get("JUJU_HOOK_NAME") or os.environ.get("JUJU_ACTION_NAME", "")
 
+
+def _get_snap_config_value(configs: Mapping[str, Any], key: str) -> Any:
+    """Return a snap config value, supporting dotted keys in nested config output."""
+    if key in configs:
+        return configs[key]
+
+    value: Any = configs
+    for part in key.split("."):
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(part)
+    return value
+
+
 def _get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
     """Check whether mandatory relations are in place.
 
@@ -639,6 +653,12 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             "web.listen-address": f":{port}",
         }
         ne_snap = self.snap("node-exporter")
+        current_configs = ne_snap.get("", typed=True)
+        if all(
+            str(_get_snap_config_value(current_configs, key) or "") == str(value)
+            for key, value in configs.items()
+        ):
+            return
         self._set_snap_configs_with_retry(ne_snap, configs)
 
     def _configure_logrotate(self):

--- a/tests/unit/test_node_exporter_snap_config.py
+++ b/tests/unit/test_node_exporter_snap_config.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import MagicMock, patch
+
+from ops.testing import State
+
+from charm import OpenTelemetryCollectorCharm
+from constants import NODE_EXPORTER_DISABLED_COLLECTORS, NODE_EXPORTER_ENABLED_COLLECTORS
+
+
+def _node_exporter_config(port: int = 9100):
+    return {
+        "collectors": " ".join(sorted(NODE_EXPORTER_ENABLED_COLLECTORS)),
+        "no-collectors": " ".join(sorted(NODE_EXPORTER_DISABLED_COLLECTORS)),
+        "web.listen-address": f":{port}",
+    }
+
+
+def _node_exporter_snap_get_config(port: int = 9100):
+    return {
+        "collectors": " ".join(sorted(NODE_EXPORTER_ENABLED_COLLECTORS)),
+        "no-collectors": " ".join(sorted(NODE_EXPORTER_DISABLED_COLLECTORS)),
+        "web": {
+            "listen-address": f":{port}",
+        },
+    }
+
+
+def test_update_status_does_not_set_matching_node_exporter_config(ctx):
+    node_exporter = MagicMock()
+    node_exporter.get.return_value = _node_exporter_snap_get_config()
+    otelcol = MagicMock()
+
+    def snap(name):
+        return {
+            "node-exporter": node_exporter,
+            "opentelemetry-collector": otelcol,
+        }[name]
+
+    with (
+        patch("charm.event", return_value="update-status"),
+        patch.object(OpenTelemetryCollectorCharm, "snap", side_effect=snap),
+        patch.object(OpenTelemetryCollectorCharm, "_restart_snap"),
+    ):
+        ctx.run(ctx.on.update_status(), State())
+
+    node_exporter.set.assert_not_called()
+
+
+def test_update_status_sets_drifted_node_exporter_config(ctx):
+    node_exporter = MagicMock()
+    node_exporter.get.return_value = _node_exporter_snap_get_config(port=9200)
+    otelcol = MagicMock()
+
+    def snap(name):
+        return {
+            "node-exporter": node_exporter,
+            "opentelemetry-collector": otelcol,
+        }[name]
+
+    with (
+        patch("charm.event", return_value="update-status"),
+        patch.object(OpenTelemetryCollectorCharm, "snap", side_effect=snap),
+        patch.object(OpenTelemetryCollectorCharm, "_restart_snap"),
+    ):
+        ctx.run(ctx.on.update_status(), State())
+
+    node_exporter.set.assert_called_once_with(_node_exporter_config())


### PR DESCRIPTION
## Issue
Avoid node-exporter snap to restart when there is no config change. Currently it restarts with every update-status hook which results in loss of metric data. For us, that triggers alerts set up based on these metrics.


## Solution
Compare the config from the charm with what is actually running in the snap, and don't restart if it is the same.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context


## Testing Instructions
Deploy and check the `snap logs node-exporter` and look for restarts when update-status hook runs.


## Upgrade Notes
