### PR TITLE
fix: Flaky itests

### DIFF
--- a/tests/integration/test_external_config.py
+++ b/tests/integration/test_external_config.py
@@ -8,24 +8,22 @@ import time
 import uuid
 
 import jubilant
-from tenacity import retry, stop_after_attempt, wait_fixed
 from helpers import PATH_EXCLUDE
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 RSYSLOG_OUTPUT_FILE = "/var/log/otelcol-integrator.log"
 RSYSLOG_REMOTE_PORT = 1514
 PATH_EXCLUDE_WITH_REMOTE_LOG = f"{PATH_EXCLUDE};{RSYSLOG_OUTPUT_FILE}*"
-
 ENABLE_IMUDP = (
     "printf '%s\\n' "
     "'module(load=\"imudp\")' "
     "'ruleset(name=\"otelcol_remote_logs\") {' "
-    f"'  action(type=\"omfile\" file=\"{RSYSLOG_OUTPUT_FILE}\")' "
+    f'\'  action(type="omfile" file="{RSYSLOG_OUTPUT_FILE}")\' '
     "'  stop' "
     "'}' "
-    f"'input(type=\"imudp\" port=\"{RSYSLOG_REMOTE_PORT}\" ruleset=\"otelcol_remote_logs\")' "
+    f'\'input(type="imudp" port="{RSYSLOG_REMOTE_PORT}" ruleset="otelcol_remote_logs")\' '
     "| sudo tee /etc/rsyslog.d/00-otelcol-imudp.conf >/dev/null"
 )
-
 OTELCOL_CONFIG = """receivers:
   loki/external:
     protocols:
@@ -64,7 +62,9 @@ def setup_rsyslog(juju: jubilant.Juju):
         "ubuntu/0",
         command=f"sudo ss -lunp | grep ':{RSYSLOG_REMOTE_PORT} ' || true",
     )
-    assert f":{RSYSLOG_REMOTE_PORT} " in listening, f"rsyslog is not listening on :{RSYSLOG_REMOTE_PORT}: {listening}"
+    assert f":{RSYSLOG_REMOTE_PORT} " in listening, (
+        f"rsyslog is not listening on :{RSYSLOG_REMOTE_PORT}: {listening}"
+    )
 
 
 def push_loki_log_to_otelcol(juju: jubilant.Juju, message: str):
@@ -125,11 +125,6 @@ def assert_log_reaches_rsyslog(juju: jubilant.Juju, message: str):
 def test_deploy_and_prepare_otelcol(juju: jubilant.Juju, charm: str):
     # GIVEN ubuntu and otelcol are deployed and related
     juju.deploy("ubuntu", channel="latest/stable", base="ubuntu@24.04")
-    juju.wait(
-        lambda status: jubilant.all_active(status, "ubuntu"),
-        error=lambda status: jubilant.any_error(status, "ubuntu"),
-        timeout=420,
-    )
     juju.deploy(
         charm,
         app="otelcol",
@@ -137,9 +132,13 @@ def test_deploy_and_prepare_otelcol(juju: jubilant.Juju, charm: str):
     )
     juju.integrate("otelcol:juju-info", "ubuntu:juju-info")
     juju.wait(
-        lambda status: jubilant.all_blocked(status, "otelcol"),
-        error=lambda status: jubilant.any_error(status, "otelcol", "ubuntu"),
-        timeout=420,
+        lambda status: (
+            jubilant.all_blocked(status, "otelcol")
+            and jubilant.all_active(status, "ubuntu")
+            and jubilant.all_agents_idle(status, "ubuntu", "otelcol")
+        ),
+        error=lambda status: jubilant.any_error,
+        timeout=600,
     )
 
     # WHEN otelcol snap is refreshed and rsyslog is prepared
@@ -161,11 +160,6 @@ def test_configure_and_relate_otelcol_integrator(juju: jubilant.Juju):
             "logs_pipeline": True,
         },
     )
-    juju.wait(
-        lambda status: jubilant.all_active(status, "otelcol-integrator"),
-        error=lambda status: jubilant.any_error(status, "otelcol-integrator"),
-        timeout=420,
-    )
 
     # WHEN otelcol consumes that external-config relation
     juju.integrate("otelcol:external-config", "otelcol-integrator:external-config")
@@ -174,11 +168,12 @@ def test_configure_and_relate_otelcol_integrator(juju: jubilant.Juju):
     # NOTE: otelcol is expected to remain blocked in this scenario (no outbound relation).
     juju.wait(
         lambda status: (
-            jubilant.all_active(status, "ubuntu", "otelcol-integrator")
-            and jubilant.all_blocked(status, "otelcol")
+            jubilant.all_blocked(status, "otelcol")
+            and jubilant.all_active(status, "ubuntu", "otelcol-integrator")
             and jubilant.all_agents_idle(status, "ubuntu", "otelcol", "otelcol-integrator")
         ),
-        timeout=420,
+        error=lambda status: jubilant.any_error,
+        timeout=600,
     )
 
 

--- a/tests/integration/test_external_config.py
+++ b/tests/integration/test_external_config.py
@@ -137,7 +137,7 @@ def test_deploy_and_prepare_otelcol(juju: jubilant.Juju, charm: str):
             and jubilant.all_active(status, "ubuntu")
             and jubilant.all_agents_idle(status, "ubuntu", "otelcol")
         ),
-        error=lambda status: jubilant.any_error,
+        error=jubilant.any_error,
         timeout=600,
     )
 
@@ -172,7 +172,7 @@ def test_configure_and_relate_otelcol_integrator(juju: jubilant.Juju):
             and jubilant.all_active(status, "ubuntu", "otelcol-integrator")
             and jubilant.all_agents_idle(status, "ubuntu", "otelcol", "otelcol-integrator")
         ),
-        error=lambda status: jubilant.any_error,
+        error=jubilant.any_error,
         timeout=600,
     )
 

--- a/tests/integration/test_tracing.py
+++ b/tests/integration/test_tracing.py
@@ -4,6 +4,7 @@
 """Feature: Ingested traces are pushed to Tempo via COS Agent."""
 
 import pathlib
+
 import jubilant
 from helpers import PATH_EXCLUDE, is_pattern_in_debug_logs
 
@@ -23,14 +24,13 @@ def test_deploy(juju: jubilant.Juju, charm_22_04: str):
     juju.integrate("otelcol:cos-agent", "postgresql:cos-agent")
     # THEN all units are active/blocked
     juju.wait(
-        lambda status: jubilant.all_blocked(status, "otelcol"),
+        lambda status: (
+            jubilant.all_blocked(status, "otelcol")
+            and jubilant.all_active(status, "postgresql")
+            and jubilant.all_agents_idle(status, "otelcol", "postgresql")
+        ),
         error=jubilant.any_error,
-        timeout=420,
-    )
-    juju.wait(
-        lambda status: jubilant.all_active(status, "postgresql"),
-        error=jubilant.any_error,
-        timeout=420,
+        timeout=600,
     )
 
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We have flaky itests in 3 main tests:
- removal_hooks
- tracing
- external_config

## Solution
<!-- A summary of the solution addressing the above issue -->
Add longer timeouts and assert statuses:
- active
- blocked
- agents_idle

before testing workload-specific assertions.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
