### PR TITLE
chore: TF remove constraints since charm is subordinate

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -28,7 +28,6 @@ No modules.
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"opentelemetry-collector"` | no |
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
 | <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
-| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
 | <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
 | <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
 | <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,6 @@
 resource "juju_application" "opentelemetry_collector" {
   name               = var.app_name
   config             = var.config
-  constraints        = var.constraints
   model_uuid         = var.model_uuid
   storage_directives = var.storage_directives
   trust              = true # We always need this variable to be true in order to be able to apply resources limits.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,16 +20,6 @@ variable "config" {
   default     = {}
 }
 
-# We use constraints to set AntiAffinity in K8s
-# https://discourse.charmhub.io/t/pod-priority-and-affinity-in-juju-charms/4091/13
-variable "constraints" {
-  description = "String listing constraints for this application"
-  type        = string
-  # FIXME: Passing an empty constraints value to the Juju Terraform provider currently
-  # causes the operation to fail due to https://github.com/juju/terraform-provider-juju/issues/344
-  default = "arch=amd64"
-}
-
 variable "model_uuid" {
   description = "Reference to an existing model resource or data source for the model to deploy to"
   type        = string


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes https://github.com/canonical/opentelemetry-collector-operator/issues/279

## Solution
<!-- A summary of the solution addressing the above issue -->
Remove the option for a user to set the `constraints` var since subordinates do not allow this:
> ╷
│ Error: Client Error
│
│ with module.otelcol.juju_application.opentelemetry_collector,
│ on .terraform/modules/otelcol/terraform/main.tf line 1, in resource "juju_application" "opentelemetry_collector":
│ 1: resource "juju_application" "opentelemetry_collector" {
│
│ Unable to create application, got error: subordinate application must be
│ deployed without constraints

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
