### PR TITLE
fix: use correct hook names for certificate relation events

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -214,8 +214,8 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
 
         if current_event in (
             "upgrade-charm",
-            "receive_ca_cert-relation-changed",
-            "receive_server_cert-relation-changed",
+            "receive-ca-cert-relation-changed",
+            "receive-server-cert-relation-changed",
             "reconcile",
         ):
             refresh_certs()

--- a/tests/unit/test_refresh_certs.py
+++ b/tests/unit/test_refresh_certs.py
@@ -16,7 +16,14 @@ from ops.testing import Relation, State
     ],
 )
 def test_refresh_certs_called_on_cert_relation_changed(ctx, relation_name, remote_app_data):
-    """Test that refresh_certs is called on certificate relation-changed hooks."""
+    """Test that refresh_certs is called on certificate relation-changed hooks.
+
+    We patch charm.event to return the real Juju hook name (all-hyphens format),
+    because the ops Scenario framework incorrectly produces a mixed format
+    with underscores in the prefix (e.g. 'receive_ca_cert-relation-changed').
+
+    Ref: https://github.com/canonical/opentelemetry-collector-operator/issues/288
+    """
     # GIVEN a certificate relation exists
     cert_relation = Relation(relation_name, remote_app_data=remote_app_data)
     state = State(
@@ -26,7 +33,8 @@ def test_refresh_certs_called_on_cert_relation_changed(ctx, relation_name, remot
 
     # Mock refresh_certs to track if it's called
     with patch("charm.refresh_certs") as mock_refresh_certs, \
-         patch("integrations._add_alerts"):
+         patch("integrations._add_alerts"), \
+         patch("charm.event", return_value=f"{relation_name}-relation-changed"):
         # WHEN the relation changed event is executed
         ctx.run(ctx.on.relation_changed(cert_relation), state)
 
@@ -63,10 +71,10 @@ def test_refresh_certs_on_reconcile_action_event(ctx):
     # WHEN the `reconcile` action is executed
     with patch("charm.refresh_certs") as mock_refresh_certs, \
          patch("integrations._add_alerts"):
-            ctx.run(
-                ctx.on.action('reconcile'),
-                state,
-            )
+        ctx.run(
+            ctx.on.action('reconcile'),
+            state,
+        )
 
-            # THEN the refresh_certs function MUST have been called once
-            mock_refresh_certs.assert_called_once()
+        # THEN the refresh_certs function MUST have been called once
+        mock_refresh_certs.assert_called_once()


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Fixes https://github.com/canonical/opentelemetry-collector-operator/issues/288

After establishing an integration on the `receive-ca-cert` endpoint, the system certificate store is never updated (`update-ca-certificates --fresh` is not executed), causing otelcol exporters to fail with `x509: certificate signed by unknown authority`.

## Solution
<!-- A summary of the solution addressing the above issue -->

The `event()` function reads `JUJU_HOOK_NAME` from the environment, which Juju sets using all-hyphens format (e.g. `receive-ca-cert-relation-changed`). The condition that gates `refresh_certs()` was comparing against strings with underscores in the relation name (`receive_ca_cert-relation-changed`), so it never matched.

Fixed by replacing underscores with hyphens in the two event name literals.

The existing unit test was also updated to patch `charm.event` with the real Juju hook name value, since the ops Scenario testing framework incorrectly produces a mixed format (`receive_ca_cert-relation-changed`) that was masking this bug.


### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Juju hook names always use hyphens as separators (e.g. `receive-ca-cert-relation-changed`). The Python ops framework internally normalizes these to underscores for Python attribute names, but the raw environment variable `JUJU_HOOK_NAME` retains the original hyphenated format.

Additionally, the ops Scenario testing framework has a bug where it reconstructs `JUJU_HOOK_NAME` with underscores preserved in the relation name prefix (`receive_ca_cert-relation-changed`), which is why the original test passed despite the charm code being incorrect.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

```shell
tox -e unit
```

To verify the fix catches the regression, revert only `src/charm.py` while keeping the test changes and confirm the tests fail:

```bash
git checkout HEAD -- src/charm.py

tox -e unit -- -k test_refresh_certs.py

# Expected: 2 FAILED (test_refresh_certs_called_on_cert_relation_changed)
```

## Upgrade Notes
<!-- To upgrade from an older revision, ... -->

After upgrading, charms with an existing `receive-ca-cert` or `receive-server-cert` relation will correctly run `update-ca-certificates --fresh` on the next `relation-changed` event, updating the system trust store without requiring a manual restart.