### PR TITLE
fix: forward related-application alert rules over `send-otlp`

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -76,7 +76,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 28
+LIBPATCH = 30
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -1168,6 +1168,26 @@ class CertificateRequestAttributes:
             and self.additional_critical_extensions == other.additional_critical_extensions
         )
 
+    def __hash__(self) -> int:
+        """Return hash of the CertificateRequestAttributes object."""
+        return hash(
+            (
+                self.common_name,
+                frozenset(self.sans_dns) if self.sans_dns else None,
+                frozenset(self.sans_ip) if self.sans_ip else None,
+                frozenset(self.sans_oid) if self.sans_oid else None,
+                self.email_address,
+                self.organization,
+                self.organizational_unit,
+                self.country_name,
+                self.state_or_province_name,
+                self.locality_name,
+                self.is_ca,
+                self.add_unique_id_to_subject_name,
+                tuple(self.additional_critical_extensions),
+            )
+        )
+
     def is_valid(self) -> bool:
         """Validate the attributes of the certificate request.
 
@@ -1733,6 +1753,7 @@ class TLSCertificatesRequiresV4(Object):
                 "Invalid renewal relative time. Must be between 0.5 and 1.0"
             )
         self._private_key = private_key
+        self._cached_private_key: Optional[PrivateKey] = None
         self.renewal_relative_time = renewal_relative_time
         self.framework.observe(charm.on[relationship_name].relation_created, self._configure)
         self.framework.observe(charm.on[relationship_name].relation_changed, self._configure)
@@ -1757,6 +1778,7 @@ class TLSCertificatesRequiresV4(Object):
         self._cleanup_certificate_requests()
         self._send_certificate_requests()
         self._find_available_certificates()
+        self._renew_expiring_certificates()
 
     def _mode_is_valid(self, mode: Mode) -> bool:
         return mode in [Mode.UNIT, Mode.APP]
@@ -1865,11 +1887,15 @@ class TLSCertificatesRequiresV4(Object):
         """Return the private key."""
         if self._private_key:
             return self._private_key
-        if not self._private_key_generated():
+        if self._cached_private_key:
+            return self._cached_private_key
+        try:
+            secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
+            private_key = secret.get_content(refresh=True)["private-key"]
+        except SecretNotFoundError:
             return None
-        secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
-        private_key = secret.get_content(refresh=True)["private-key"]
-        return PrivateKey.from_string(private_key)
+        self._cached_private_key = PrivateKey.from_string(private_key)
+        return self._cached_private_key
 
     def _ensure_private_key(self) -> None:
         """Make sure there is a private key to be used.
@@ -1884,6 +1910,9 @@ class TLSCertificatesRequiresV4(Object):
             return
         if self._private_key_generated():
             logger.debug("Private key already generated")
+            return
+        if self.mode == Mode.APP and not self.model.unit.is_leader():
+            logger.debug("Not leader, skipping private key generation in APP mode")
             return
         self._generate_private_key()
 
@@ -1901,6 +1930,9 @@ class TLSCertificatesRequiresV4(Object):
                 "Private key is passed by the charm through the private_key parameter, "
                 "this function can't be used"
             )
+        if self.mode == Mode.APP and not self.model.unit.is_leader():
+            logger.warning("Only the leader can regenerate the private key in APP mode")
+            return
         if not self._private_key_generated():
             logger.warning("No private key to regenerate")
             return
@@ -1932,18 +1964,24 @@ class TLSCertificatesRequiresV4(Object):
             return False
 
     def _store_private_key_in_secret(self, private_key: PrivateKey) -> None:
+        self._cached_private_key = None
         try:
             secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
             secret.set_content({"private-key": str(private_key)})
             secret.get_content(refresh=True)
         except SecretNotFoundError:
-            self.charm.unit.add_secret(
+            app_or_unit = self._get_app_or_unit()
+            app_or_unit.add_secret(
                 content={"private-key": str(private_key)},
                 label=self._get_private_key_secret_label(),
             )
 
     def _remove_private_key_secret(self) -> None:
         """Remove the private key secret."""
+        self._cached_private_key = None
+        if self.mode == Mode.APP and not self.model.unit.is_leader():
+            logger.debug("Not leader, cannot remove app owned private key secret")
+            return
         try:
             secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
             secret.remove_all_revisions()
@@ -2225,6 +2263,32 @@ class TLSCertificatesRequiresV4(Object):
                 logger.info(
                     "Removed CSR from relation data because it did not match the private key"  # noqa: E501
                 )
+
+    def _renew_expiring_certificates(self) -> None:
+        """Renew certificates approaching expiry that haven't been renewed yet.
+
+        This acts as a safety net for cases where secret_expired failed to trigger or complete.
+        Checks certificates at a threshold slightly after the configured renewal time but before
+        expiry to prevent downtime.
+        """
+        now = datetime.now(timezone.utc)
+        safety_threshold = min(0.99, self.renewal_relative_time + 0.05)
+
+        assigned_certificates, _ = self.get_assigned_certificates()
+
+        for provider_certificate in assigned_certificates:
+            cert = provider_certificate.certificate
+            validity_start = cert.validity_start_time
+            validity_end = cert.expiry_time
+            validity_period = validity_end - validity_start
+            safety_renewal_time = validity_start + (validity_period * safety_threshold)
+
+            if now >= safety_renewal_time and now < validity_end:
+                logger.warning(
+                    "Certificate approaching expiry but not renewed - "
+                    "triggering renewal as safety net"
+                )
+                self._renew_certificate_request(provider_certificate.certificate_signing_request)
 
     def _tls_relation_created(self) -> bool:
         relation = self.model.get_relation(self.relationship_name)

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -76,7 +76,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 30
+LIBPATCH = 28
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -1168,26 +1168,6 @@ class CertificateRequestAttributes:
             and self.additional_critical_extensions == other.additional_critical_extensions
         )
 
-    def __hash__(self) -> int:
-        """Return hash of the CertificateRequestAttributes object."""
-        return hash(
-            (
-                self.common_name,
-                frozenset(self.sans_dns) if self.sans_dns else None,
-                frozenset(self.sans_ip) if self.sans_ip else None,
-                frozenset(self.sans_oid) if self.sans_oid else None,
-                self.email_address,
-                self.organization,
-                self.organizational_unit,
-                self.country_name,
-                self.state_or_province_name,
-                self.locality_name,
-                self.is_ca,
-                self.add_unique_id_to_subject_name,
-                tuple(self.additional_critical_extensions),
-            )
-        )
-
     def is_valid(self) -> bool:
         """Validate the attributes of the certificate request.
 
@@ -1753,7 +1733,6 @@ class TLSCertificatesRequiresV4(Object):
                 "Invalid renewal relative time. Must be between 0.5 and 1.0"
             )
         self._private_key = private_key
-        self._cached_private_key: Optional[PrivateKey] = None
         self.renewal_relative_time = renewal_relative_time
         self.framework.observe(charm.on[relationship_name].relation_created, self._configure)
         self.framework.observe(charm.on[relationship_name].relation_changed, self._configure)
@@ -1778,7 +1757,6 @@ class TLSCertificatesRequiresV4(Object):
         self._cleanup_certificate_requests()
         self._send_certificate_requests()
         self._find_available_certificates()
-        self._renew_expiring_certificates()
 
     def _mode_is_valid(self, mode: Mode) -> bool:
         return mode in [Mode.UNIT, Mode.APP]
@@ -1887,15 +1865,11 @@ class TLSCertificatesRequiresV4(Object):
         """Return the private key."""
         if self._private_key:
             return self._private_key
-        if self._cached_private_key:
-            return self._cached_private_key
-        try:
-            secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
-            private_key = secret.get_content(refresh=True)["private-key"]
-        except SecretNotFoundError:
+        if not self._private_key_generated():
             return None
-        self._cached_private_key = PrivateKey.from_string(private_key)
-        return self._cached_private_key
+        secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
+        private_key = secret.get_content(refresh=True)["private-key"]
+        return PrivateKey.from_string(private_key)
 
     def _ensure_private_key(self) -> None:
         """Make sure there is a private key to be used.
@@ -1910,9 +1884,6 @@ class TLSCertificatesRequiresV4(Object):
             return
         if self._private_key_generated():
             logger.debug("Private key already generated")
-            return
-        if self.mode == Mode.APP and not self.model.unit.is_leader():
-            logger.debug("Not leader, skipping private key generation in APP mode")
             return
         self._generate_private_key()
 
@@ -1930,9 +1901,6 @@ class TLSCertificatesRequiresV4(Object):
                 "Private key is passed by the charm through the private_key parameter, "
                 "this function can't be used"
             )
-        if self.mode == Mode.APP and not self.model.unit.is_leader():
-            logger.warning("Only the leader can regenerate the private key in APP mode")
-            return
         if not self._private_key_generated():
             logger.warning("No private key to regenerate")
             return
@@ -1964,24 +1932,18 @@ class TLSCertificatesRequiresV4(Object):
             return False
 
     def _store_private_key_in_secret(self, private_key: PrivateKey) -> None:
-        self._cached_private_key = None
         try:
             secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
             secret.set_content({"private-key": str(private_key)})
             secret.get_content(refresh=True)
         except SecretNotFoundError:
-            app_or_unit = self._get_app_or_unit()
-            app_or_unit.add_secret(
+            self.charm.unit.add_secret(
                 content={"private-key": str(private_key)},
                 label=self._get_private_key_secret_label(),
             )
 
     def _remove_private_key_secret(self) -> None:
         """Remove the private key secret."""
-        self._cached_private_key = None
-        if self.mode == Mode.APP and not self.model.unit.is_leader():
-            logger.debug("Not leader, cannot remove app owned private key secret")
-            return
         try:
             secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
             secret.remove_all_revisions()
@@ -2263,32 +2225,6 @@ class TLSCertificatesRequiresV4(Object):
                 logger.info(
                     "Removed CSR from relation data because it did not match the private key"  # noqa: E501
                 )
-
-    def _renew_expiring_certificates(self) -> None:
-        """Renew certificates approaching expiry that haven't been renewed yet.
-
-        This acts as a safety net for cases where secret_expired failed to trigger or complete.
-        Checks certificates at a threshold slightly after the configured renewal time but before
-        expiry to prevent downtime.
-        """
-        now = datetime.now(timezone.utc)
-        safety_threshold = min(0.99, self.renewal_relative_time + 0.05)
-
-        assigned_certificates, _ = self.get_assigned_certificates()
-
-        for provider_certificate in assigned_certificates:
-            cert = provider_certificate.certificate
-            validity_start = cert.validity_start_time
-            validity_end = cert.expiry_time
-            validity_period = validity_end - validity_start
-            safety_renewal_time = validity_start + (validity_period * safety_threshold)
-
-            if now >= safety_renewal_time and now < validity_end:
-                logger.warning(
-                    "Certificate approaching expiry but not renewed - "
-                    "triggering renewal as safety net"
-                )
-                self._renew_certificate_request(provider_certificate.certificate_signing_request)
 
     def _tls_relation_created(self) -> bool:
         relation = self.model.get_relation(self.relationship_name)

--- a/src/charm.py
+++ b/src/charm.py
@@ -193,7 +193,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         # come from peer data, so the leader can access all of them, regardless where multiple
         # principals are located.
         if self.unit.is_leader():
-            integrations.cleanup()
+            integrations.cleanup(self.charm_dir.absolute())
 
         # Integrate with TLS relations
         receive_ca_certs_hash = integrations.receive_ca_cert(
@@ -445,10 +445,6 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             config_manager.add_log_ingestion()
         config_manager.add_log_forwarding(loki_endpoints, insecure_skip_verify)
 
-        # OTLP setup
-        otlp_endpoints = integrations.send_otlp(self)
-        config_manager.add_otlp_forwarding(otlp_endpoints)
-
         # Metrics setup
         config_manager.add_self_scrape(
             identifier=topology.identifier,
@@ -480,6 +476,14 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             # This is conditional because otherwise remote_write.endpoints causes error on relation-broken
             remote_write_endpoints = integrations.send_remote_write(self)
             config_manager.add_remote_write(remote_write_endpoints)
+
+        # OTLP setup
+        # NOTE: this must run after the logs/metrics/cos-agent integrations above so that the
+        # *_RULES_DEST_PATH directories contain the alert rules gathered from related applications
+        # (e.g. postgresql). Otherwise those rules would be dropped from the OTLP databag.
+        # See https://github.com/canonical/opentelemetry-collector-operator/issues/297
+        otlp_endpoints = integrations.send_otlp(self)
+        config_manager.add_otlp_forwarding(otlp_endpoints)
 
         # Dashboards setup
         ## COS Agent dashboards

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -66,14 +66,17 @@ logger = logging.getLogger(__name__)
 ProfilingEndpoint = namedtuple("ProfilingEndpoint", "endpoint, insecure")
 
 
-def cleanup():
+def cleanup(charm_root: Path):
     """Cleanup folders for alerts and dashboards.
 
     This function should be called before all integrations to ensure the charm works holistically.
+    The DEST directories are resolved against ``charm_root`` (an absolute path) so that cleanup
+    targets the very same folders that `receive_loki_logs`/`scrape_metrics`/`send_otlp` read and
+    write, regardless of the process' current working directory.
     """
-    shutil.rmtree(METRICS_RULES_DEST_PATH, ignore_errors=True)
-    shutil.rmtree(LOKI_RULES_DEST_PATH, ignore_errors=True)
-    shutil.rmtree(DASHBOARDS_DEST_PATH, ignore_errors=True)
+    shutil.rmtree(charm_root.joinpath(*METRICS_RULES_DEST_PATH.split("/")), ignore_errors=True)
+    shutil.rmtree(charm_root.joinpath(*LOKI_RULES_DEST_PATH.split("/")), ignore_errors=True)
+    shutil.rmtree(charm_root.joinpath(*DASHBOARDS_DEST_PATH.split("/")), ignore_errors=True)
 
 
 def _add_alerts(alerts: Dict, dest_path: Path):
@@ -471,16 +474,25 @@ def send_otlp(charm: CharmBase) -> Dict[int, OtlpEndpoint]:
 
     This provides otelcol with the remote's OTLP endpoint for each relation.
 
-    The bundled rule files (from the src/*_rules directories) are published to the databag.
-    Conditional to the `forward_alert_rules` config, the rules from related OTLP requirer charms
-    are also published to the databag.
+    The rule files staged in the *_RULES_DEST_PATH directories are published to the databag.
+    These directories contain both the charm's own bundled rules (copied from src/*_rules) and,
+    conditional to the `forward_alert_rules` config, the alert rules gathered from related
+    applications. The DEST directories are populated, in order, by:
+      * `scrape_metrics`        -> metrics-endpoint alerts  (METRICS_RULES_DEST_PATH)
+      * `receive_loki_logs`     -> receive-loki-logs alerts (LOKI_RULES_DEST_PATH)
+      * the cos-agent handling in `charm.reconcile` (leader-only) -> cos-agent metrics/logs alerts
+
+    NOTE: This function MUST be called after all of the above have run, so that the DEST
+    directories are fully populated before being forwarded. Otherwise alert rules from related
+    applications (e.g. postgresql) would be silently dropped from the OTLP databag.
+    See https://github.com/canonical/opentelemetry-collector-operator/issues/297
     """
-    # Gather our bundled rules
+    # Gather all staged rules: bundled rules plus the alerts forwarded by related applications.
     charm_root = charm.charm_dir.absolute()
     rules = (
         RuleStore(JujuTopology.from_charm(charm))
-        .add_logql_path(charm_root.joinpath(LOKI_RULES_SRC_PATH), recursive=True)
-        .add_promql_path(charm_root.joinpath(METRICS_RULES_SRC_PATH), recursive=True)
+        .add_logql_path(charm_root.joinpath(LOKI_RULES_DEST_PATH), recursive=True)
+        .add_promql_path(charm_root.joinpath(METRICS_RULES_DEST_PATH), recursive=True)
     )
     # Publish rules for the provider
     extra_alert_labels = cast(str, charm.model.config.get("extra_alert_labels", ""))

--- a/tests/unit/test_otlp.py
+++ b/tests/unit/test_otlp.py
@@ -4,11 +4,14 @@
 """Feature: OTLP endpoints and rules transfer."""
 
 import json
+from contextlib import ExitStack
+from unittest.mock import patch
 
 import pytest
 from charmlibs.interfaces.otlp import OtlpEndpoint
+from charms.grafana_agent.v0.cos_agent import CosAgentProviderUnitData
 from cosl.utils import LZMABase64
-from ops.testing import Model, Relation, State
+from ops.testing import Model, PeerRelation, Relation, State, SubordinateRelation
 
 from src.integrations import send_otlp
 
@@ -23,9 +26,59 @@ OTELCOL_METADATA = {
     "charm_name": "opentelemetry-collector",
 }
 
+# A marker alert rule provided by a related application (e.g. postgresql).
+RELATED_APP_ALERT = "PostgresqlInvalidIndex"
+# A marker log (logql) alert rule provided by a related application over `receive-loki-logs`.
+RELATED_APP_LOG_ALERT = "ZincTooManyLogs"
+
+
+def _postgresql_alert_groups() -> dict:
+    """Return a `{"groups": [...]}` alert-rules payload for the postgresql marker alert."""
+    return {
+        "groups": [
+            {
+                "name": "postgresql_index_group",
+                "rules": [
+                    {
+                        "alert": RELATED_APP_ALERT,
+                        "expr": "pg_general_index_info_pg_relation_size > 0",
+                        "for": "6h",
+                        "labels": {
+                            "severity": "critical",
+                            "juju_model": MODEL_NAME,
+                            "juju_model_uuid": MODEL_UUID,
+                            "juju_application": "postgresql",
+                            "juju_charm": "postgresql",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+
+# Alert rules as provided by an application related over `metrics-endpoint`
+# (the relation databag funnels alert rules through as a JSON string).
+RELATED_APP_ALERT_RULES = {"alert_rules": json.dumps(_postgresql_alert_groups())}
+
 
 def _decompress(rules: str) -> dict:
+    assert rules, "expected a non-empty compressed `rules` databag value"
     return json.loads(LZMABase64.decompress(rules))
+
+
+def _forwarded_rules(decompressed: dict, kind: str) -> list:
+    """Flatten the rules of a given kind ('promql' or 'logql') from a decompressed databag."""
+    return [
+        rule
+        for group in decompressed[kind].get("groups", [])
+        for rule in group.get("rules", [])
+    ]
+
+
+def _forwarded_alert_names(decompressed: dict, kind: str = "promql") -> set:
+    """Collect the alert names of a given kind from a decompressed databag."""
+    return {rule.get("alert") for rule in _forwarded_rules(decompressed, kind)}
 
 
 def test_send_otlp(ctx):
@@ -120,6 +173,223 @@ def test_forwarding_otlp_rule_counts(ctx, forward_rules):
             assert not logql_group_names
             bundled_rule_base_name = f"{MODEL_NAME}_f4d59020_otelcol".replace('-', '_')
             assert f"{bundled_rule_base_name}_Exporter_rules" in promql_group_names
+
+
+@pytest.mark.parametrize("forward_rules", [True, False])
+def test_related_app_alerts_forwarded_over_otlp(ctx, forward_rules):
+    """Regression test for https://github.com/canonical/opentelemetry-collector-operator/issues/297.
+
+    Alert rules from applications related over `metrics-endpoint`/`cos-agent` (e.g. postgresql)
+    must be forwarded in the `send-otlp` relation databag, not only the charm's bundled rules.
+    """
+    # GIVEN an app providing alert rules over metrics-endpoint AND a send-otlp relation
+    metrics_endpoint = Relation(
+        "metrics-endpoint",
+        remote_app_name="postgresql",
+        remote_app_data=RELATED_APP_ALERT_RULES,
+    )
+    send_otlp_relation = Relation("send-otlp", remote_app_data={"endpoints": "[]"})
+    state = State(
+        relations=[metrics_endpoint, send_otlp_relation],
+        leader=True,
+        model=MODEL,
+        config={"forward_alert_rules": forward_rules},
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the related app's alert rule is present in the send-otlp databag iff forwarding is on
+    out_relation = state_out.get_relation(send_otlp_relation.id)
+    decompressed = _decompress(out_relation.local_app_data.get("rules"))
+    forwarded_rules = _forwarded_rules(decompressed, "promql")
+    forwarded_alerts = {rule.get("alert") for rule in forwarded_rules}
+    if forward_rules:
+        assert RELATED_APP_ALERT in forwarded_alerts
+        # AND the related app's juju topology labels are preserved on the forwarded rule
+        marker = next(r for r in forwarded_rules if r.get("alert") == RELATED_APP_ALERT)
+        assert marker["labels"]["juju_application"] == "postgresql"
+    else:
+        assert RELATED_APP_ALERT not in forwarded_alerts
+
+
+@pytest.mark.parametrize("forward_rules", [True, False])
+def test_related_app_alerts_forwarded_over_otlp_via_cos_agent(ctx, forward_rules):
+    """Regression test for https://github.com/canonical/opentelemetry-collector-operator/issues/297.
+
+    Same as `test_related_app_alerts_forwarded_over_otlp` but exercising the real `cos-agent`
+    subordinate path (the one postgresql uses in production), where alert rules arrive in the
+    principal unit databag, are copied into the peer relation by the cos-agent library during
+    reconcile, then staged to disk and forwarded over OTLP.
+
+    NOTE: Unlike the metrics-endpoint/loki paths, the cos-agent alert staging in `charm._reconcile`
+    is gated only on `is_leader()` (not on `forward_alert_rules`), so cos-agent alerts are forwarded
+    regardless of that config. This mirrors the pre-existing cos-agent -> remote-write behaviour.
+    """
+    # GIVEN a principal app (postgresql) related over the cos-agent subordinate relation,
+    # publishing metrics alert rules in its unit databag
+    provider_data = CosAgentProviderUnitData(
+        metrics_alert_rules=_postgresql_alert_groups(),
+        log_alert_rules={},
+        dashboards=[],
+        metrics_scrape_jobs=[],
+        log_slots=[],
+    )
+    cos_agent = SubordinateRelation(
+        "cos-agent",
+        remote_app_name="postgresql",
+        remote_unit_id=0,
+        remote_unit_data={CosAgentProviderUnitData.KEY: provider_data.json()},
+    )
+    # AND a peers relation (the cos-agent leader stores principal data there) and a send-otlp relation
+    peers = PeerRelation("peers")
+    send_otlp_relation = Relation("send-otlp", remote_app_data={"endpoints": "[]"})
+    state = State(
+        relations=[cos_agent, peers, send_otlp_relation],
+        leader=True,
+        model=MODEL,
+        config={"forward_alert_rules": forward_rules},
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the related app's alert rule is present in the send-otlp databag (leader-gated only)
+    out_relation = state_out.get_relation(send_otlp_relation.id)
+    decompressed = _decompress(out_relation.local_app_data.get("rules"))
+    forwarded_alerts = _forwarded_alert_names(decompressed, "promql")
+    assert RELATED_APP_ALERT in forwarded_alerts
+
+
+@pytest.mark.parametrize("forward_rules", [True, False])
+def test_related_app_log_alerts_forwarded_over_otlp(ctx, forward_rules):
+    """Log (logql) alert rules received over `receive-loki-logs` must also be forwarded over OTLP."""
+    # GIVEN an app providing log alert rules over receive-loki-logs AND a send-otlp relation
+    log_alerts = {
+        "alert_rules": json.dumps(
+            {
+                "groups": [
+                    {
+                        "name": "zinc_log_group",
+                        "rules": [
+                            {
+                                "alert": RELATED_APP_LOG_ALERT,
+                                "expr": 'rate({juju_application="zinc"}[5m]) > 100',
+                                "for": "5m",
+                                "labels": {
+                                    "severity": "warning",
+                                    "juju_model": MODEL_NAME,
+                                    "juju_model_uuid": MODEL_UUID,
+                                    "juju_application": "zinc",
+                                    "juju_charm": "zinc-k8s",
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    }
+    receive_loki_logs = Relation(
+        "receive-loki-logs",
+        remote_app_name="zinc",
+        remote_app_data=log_alerts,
+    )
+    send_otlp_relation = Relation("send-otlp", remote_app_data={"endpoints": "[]"})
+    state = State(
+        relations=[receive_loki_logs, send_otlp_relation],
+        leader=True,
+        model=MODEL,
+        config={"forward_alert_rules": forward_rules},
+    )
+
+    # WHEN any event executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN the related app's log alert rule is present in the logql databag iff forwarding is on
+    out_relation = state_out.get_relation(send_otlp_relation.id)
+    decompressed = _decompress(out_relation.local_app_data.get("rules"))
+    forwarded_log_alerts = _forwarded_alert_names(decompressed, "logql")
+    if forward_rules:
+        assert RELATED_APP_LOG_ALERT in forwarded_log_alerts
+    else:
+        assert RELATED_APP_LOG_ALERT not in forwarded_log_alerts
+
+
+def test_reconcile_stages_otlp_rules_after_related_app_staging(ctx):
+    """Guard the temporal ordering contract that makes OTLP rule forwarding work.
+
+    `send_otlp` forwards whatever rule files are staged in the *_RULES_DEST_PATH directories, so it
+    MUST run:
+      * AFTER `cleanup` (which wipes the rule directories), and
+      * AFTER every integration that stages related-app alerts into those directories:
+        `scrape_metrics` (metrics-endpoint), `receive_loki_logs` (loki) and the cos-agent
+        `_add_alerts` calls in `charm._reconcile`.
+
+    This ordering is otherwise only enforced by a code comment, so a future reorder would silently
+    regress https://github.com/canonical/opentelemetry-collector-operator/issues/297. This test
+    spies on the reconcile call order to fail fast if that contract is broken.
+    """
+    # `charm.py` does `import integrations`, so spy on that same module object
+    import integrations
+
+    call_order: list[str] = []
+    spied = [
+        "cleanup",
+        "_add_alerts",  # cos-agent metrics/logs alerts staged from charm._reconcile
+        "receive_loki_logs",
+        "scrape_metrics",
+        "send_otlp",
+    ]
+    real = {name: getattr(integrations, name) for name in spied}
+
+    def make_spy(name):
+        def spy(*args, **kwargs):
+            call_order.append(name)
+            return real[name](*args, **kwargs)
+
+        return spy
+
+    # GIVEN a cos-agent principal staging alerts, a peers relation, and a send-otlp relation
+    provider_data = CosAgentProviderUnitData(
+        metrics_alert_rules=_postgresql_alert_groups(),
+        log_alert_rules={},
+        dashboards=[],
+        metrics_scrape_jobs=[],
+        log_slots=[],
+    )
+    cos_agent = SubordinateRelation(
+        "cos-agent",
+        remote_app_name="postgresql",
+        remote_unit_id=0,
+        remote_unit_data={CosAgentProviderUnitData.KEY: provider_data.json()},
+    )
+    state = State(
+        relations=[
+            cos_agent,
+            PeerRelation("peers"),
+            Relation("send-otlp", remote_app_data={"endpoints": "[]"}),
+        ],
+        leader=True,
+        model=MODEL,
+        config={"forward_alert_rules": True},
+    )
+
+    # WHEN any event executes the reconciler
+    with ExitStack() as stack:
+        for name in spied:
+            stack.enter_context(patch.object(integrations, name, make_spy(name)))
+        ctx.run(ctx.on.update_status(), state=state)
+
+    # THEN send_otlp runs after cleanup and after every related-app staging step
+    assert "send_otlp" in call_order
+    send_otlp_idx = call_order.index("send_otlp")
+    assert call_order.index("cleanup") < send_otlp_idx
+    for stager in ("_add_alerts", "receive_loki_logs", "scrape_metrics"):
+        assert stager in call_order, f"{stager} was not called"
+        # Use the LAST occurrence: every staging write must precede the forwarding read
+        last_idx = len(call_order) - 1 - call_order[::-1].index(stager)
+        assert last_idx < send_otlp_idx, f"send_otlp must run after {stager}"
 
 
 def test_forwarded_rules_have_topology(ctx):

--- a/tests/unit/test_otlp.py
+++ b/tests/unit/test_otlp.py
@@ -74,11 +74,6 @@ def _forwarded_rules(decompressed: dict, kind: str) -> list:
     ]
 
 
-def _forwarded_alert_names(decompressed: dict, kind: str = "promql") -> set:
-    """Collect the alert names of a given kind from a decompressed databag."""
-    return {rule.get("alert") for rule in _forwarded_rules(decompressed, kind)}
-
-
 def test_send_otlp(ctx):
     # GIVEN otelcol supports (defined by OtlpRequirer) a subset of OTLP protocols and telemetries
     # * a remote app provides multiple OtlpEndpoints
@@ -173,59 +168,50 @@ def test_forwarding_otlp_rule_counts(ctx, forward_rules):
             assert f"{bundled_rule_base_name}_Exporter_rules" in promql_group_names
 
 
-@pytest.mark.parametrize("forward_rules", [True, False])
-def test_related_app_alerts_forwarded_over_otlp(ctx, forward_rules):
-    """Regression test for https://github.com/canonical/opentelemetry-collector-operator/issues/297.
+def _zinc_log_alert_groups() -> dict:
+    """Return a `{"groups": [...]}` logql alert-rules payload for the zinc marker log alert."""
+    return {
+        "groups": [
+            {
+                "name": "zinc_log_group",
+                "rules": [
+                    {
+                        "alert": RELATED_APP_LOG_ALERT,
+                        "expr": 'rate({juju_application="zinc"}[5m]) > 100',
+                        "for": "5m",
+                        "labels": {
+                            "severity": "warning",
+                            "juju_model": MODEL_NAME,
+                            "juju_model_uuid": MODEL_UUID,
+                            "juju_application": "zinc",
+                            "juju_charm": "zinc-k8s",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
 
-    Alert rules from applications related over `metrics-endpoint`/`cos-agent` (e.g. postgresql)
-    must be forwarded in the `send-otlp` relation databag, not only the charm's bundled rules.
+
+def _metrics_endpoint_source() -> list:
+    """Source: an app related over `metrics-endpoint` (e.g. postgresql) providing promql rules."""
+    return [
+        Relation(
+            "metrics-endpoint",
+            remote_app_name="postgresql",
+            remote_app_data=RELATED_APP_ALERT_RULES,
+        )
+    ]
+
+
+def _cos_agent_source() -> list:
+    """Source: a principal app (postgresql) related over the `cos-agent` subordinate relation.
+
+    This is the real path postgresql uses in production: alert rules arrive in the principal unit
+    databag, are copied into the peer relation by the cos-agent library during reconcile, then
+    staged to disk and forwarded over OTLP. A `peers` relation is required for the leader to store
+    the principal data.
     """
-    # GIVEN an app providing alert rules over metrics-endpoint AND a send-otlp relation
-    metrics_endpoint = Relation(
-        "metrics-endpoint",
-        remote_app_name="postgresql",
-        remote_app_data=RELATED_APP_ALERT_RULES,
-    )
-    send_otlp_relation = Relation("send-otlp", remote_app_data={"endpoints": "[]"})
-    state = State(
-        relations=[metrics_endpoint, send_otlp_relation],
-        leader=True,
-        model=MODEL,
-        config={"forward_alert_rules": forward_rules},
-    )
-
-    # WHEN any event executes the reconciler
-    state_out = ctx.run(ctx.on.update_status(), state=state)
-
-    # THEN the related app's alert rule is present in the send-otlp databag iff forwarding is on
-    out_relation = state_out.get_relation(send_otlp_relation.id)
-    decompressed = _decompress(out_relation.local_app_data.get("rules"))
-    forwarded_rules = _forwarded_rules(decompressed, "promql")
-    forwarded_alerts = {rule.get("alert") for rule in forwarded_rules}
-    if forward_rules:
-        assert RELATED_APP_ALERT in forwarded_alerts
-        # AND the related app's juju topology labels are preserved on the forwarded rule
-        marker = next(r for r in forwarded_rules if r.get("alert") == RELATED_APP_ALERT)
-        assert marker["labels"]["juju_application"] == "postgresql"
-    else:
-        assert RELATED_APP_ALERT not in forwarded_alerts
-
-
-@pytest.mark.parametrize("forward_rules", [True, False])
-def test_related_app_alerts_forwarded_over_otlp_via_cos_agent(ctx, forward_rules):
-    """Regression test for https://github.com/canonical/opentelemetry-collector-operator/issues/297.
-
-    Same as `test_related_app_alerts_forwarded_over_otlp` but exercising the real `cos-agent`
-    subordinate path (the one postgresql uses in production), where alert rules arrive in the
-    principal unit databag, are copied into the peer relation by the cos-agent library during
-    reconcile, then staged to disk and forwarded over OTLP.
-
-    NOTE: Unlike the metrics-endpoint/loki paths, the cos-agent alert staging in `charm._reconcile`
-    is gated only on `is_leader()` (not on `forward_alert_rules`), so cos-agent alerts are forwarded
-    regardless of that config. This mirrors the pre-existing cos-agent -> remote-write behaviour.
-    """
-    # GIVEN a principal app (postgresql) related over the cos-agent subordinate relation,
-    # publishing metrics alert rules in its unit databag
     provider_data = CosAgentProviderUnitData(
         metrics_alert_rules=_postgresql_alert_groups(),
         log_alert_rules={},
@@ -233,69 +219,76 @@ def test_related_app_alerts_forwarded_over_otlp_via_cos_agent(ctx, forward_rules
         metrics_scrape_jobs=[],
         log_slots=[],
     )
-    cos_agent = SubordinateRelation(
-        "cos-agent",
-        remote_app_name="postgresql",
-        remote_unit_id=0,
-        remote_unit_data={CosAgentProviderUnitData.KEY: provider_data.json()},
-    )
-    # AND a peers relation (the cos-agent leader stores principal data there) and a send-otlp relation
-    peers = PeerRelation("peers")
-    send_otlp_relation = Relation("send-otlp", remote_app_data={"endpoints": "[]"})
-    state = State(
-        relations=[cos_agent, peers, send_otlp_relation],
-        leader=True,
-        model=MODEL,
-        config={"forward_alert_rules": forward_rules},
-    )
+    return [
+        SubordinateRelation(
+            "cos-agent",
+            remote_app_name="postgresql",
+            remote_unit_id=0,
+            remote_unit_data={CosAgentProviderUnitData.KEY: provider_data.json()},
+        ),
+        PeerRelation("peers"),
+    ]
 
-    # WHEN any event executes the reconciler
-    state_out = ctx.run(ctx.on.update_status(), state=state)
 
-    # THEN the related app's alert rule is present in the send-otlp databag (leader-gated only)
-    out_relation = state_out.get_relation(send_otlp_relation.id)
-    decompressed = _decompress(out_relation.local_app_data.get("rules"))
-    forwarded_alerts = _forwarded_alert_names(decompressed, "promql")
-    assert RELATED_APP_ALERT in forwarded_alerts
+def _receive_loki_logs_source() -> list:
+    """Source: an app related over `receive-loki-logs` (e.g. zinc) providing logql rules."""
+    return [
+        Relation(
+            "receive-loki-logs",
+            remote_app_name="zinc",
+            remote_app_data={"alert_rules": json.dumps(_zinc_log_alert_groups())},
+        )
+    ]
 
 
 @pytest.mark.parametrize("forward_rules", [True, False])
-def test_related_app_log_alerts_forwarded_over_otlp(ctx, forward_rules):
-    """Log (logql) alert rules received over `receive-loki-logs` must also be forwarded over OTLP."""
-    # GIVEN an app providing log alert rules over receive-loki-logs AND a send-otlp relation
-    log_alerts = {
-        "alert_rules": json.dumps(
-            {
-                "groups": [
-                    {
-                        "name": "zinc_log_group",
-                        "rules": [
-                            {
-                                "alert": RELATED_APP_LOG_ALERT,
-                                "expr": 'rate({juju_application="zinc"}[5m]) > 100',
-                                "for": "5m",
-                                "labels": {
-                                    "severity": "warning",
-                                    "juju_model": MODEL_NAME,
-                                    "juju_model_uuid": MODEL_UUID,
-                                    "juju_application": "zinc",
-                                    "juju_charm": "zinc-k8s",
-                                },
-                            }
-                        ],
-                    }
-                ]
-            }
-        )
-    }
-    receive_loki_logs = Relation(
-        "receive-loki-logs",
-        remote_app_name="zinc",
-        remote_app_data=log_alerts,
-    )
+@pytest.mark.parametrize(
+    "make_source, kind, marker_alert, juju_app, always_forwarded",
+    [
+        pytest.param(
+            _metrics_endpoint_source,
+            "promql",
+            RELATED_APP_ALERT,
+            "postgresql",
+            False,
+            id="metrics-endpoint",
+        ),
+        pytest.param(
+            _cos_agent_source,
+            "promql",
+            RELATED_APP_ALERT,
+            "postgresql",
+            True,
+            id="cos-agent",
+        ),
+        pytest.param(
+            _receive_loki_logs_source,
+            "logql",
+            RELATED_APP_LOG_ALERT,
+            "zinc",
+            False,
+            id="receive-loki-logs",
+        ),
+    ],
+)
+def test_related_app_alerts_forwarded_over_otlp(
+    ctx, make_source, kind, marker_alert, juju_app, always_forwarded, forward_rules
+):
+    """Regression test for https://github.com/canonical/opentelemetry-collector-operator/issues/297.
+
+    Alert rules from an application related over `metrics-endpoint`, `cos-agent` or
+    `receive-loki-logs` (e.g. postgresql, zinc) must be forwarded in the `send-otlp` relation
+    databag, not only the charm's bundled rules.
+
+    NOTE: Unlike the metrics-endpoint/loki paths, the cos-agent alert staging in `charm._reconcile`
+    is gated only on `is_leader()` (not on `forward_alert_rules`), so cos-agent alerts are forwarded
+    regardless of that config (``always_forwarded``). This mirrors the pre-existing cos-agent ->
+    remote-write behaviour.
+    """
+    # GIVEN an app providing alert rules over the source relation AND a send-otlp relation
     send_otlp_relation = Relation("send-otlp", remote_app_data={"endpoints": "[]"})
     state = State(
-        relations=[receive_loki_logs, send_otlp_relation],
+        relations=[*make_source(), send_otlp_relation],
         leader=True,
         model=MODEL,
         config={"forward_alert_rules": forward_rules},
@@ -304,14 +297,18 @@ def test_related_app_log_alerts_forwarded_over_otlp(ctx, forward_rules):
     # WHEN any event executes the reconciler
     state_out = ctx.run(ctx.on.update_status(), state=state)
 
-    # THEN the related app's log alert rule is present in the logql databag iff forwarding is on
+    # THEN the related app's alert rule is present in the send-otlp databag iff forwarding applies
     out_relation = state_out.get_relation(send_otlp_relation.id)
     decompressed = _decompress(out_relation.local_app_data.get("rules"))
-    forwarded_log_alerts = _forwarded_alert_names(decompressed, "logql")
-    if forward_rules:
-        assert RELATED_APP_LOG_ALERT in forwarded_log_alerts
+    forwarded_rules = _forwarded_rules(decompressed, kind)
+    forwarded_alerts = {rule.get("alert") for rule in forwarded_rules}
+    if forward_rules or always_forwarded:
+        assert marker_alert in forwarded_alerts
+        # AND the related app's juju topology labels are preserved on the forwarded rule
+        marker = next(r for r in forwarded_rules if r.get("alert") == marker_alert)
+        assert marker["labels"]["juju_application"] == juju_app
     else:
-        assert RELATED_APP_LOG_ALERT not in forwarded_log_alerts
+        assert marker_alert not in forwarded_alerts
 
 
 def test_forwarded_rules_have_topology(ctx):

--- a/tests/unit/test_otlp.py
+++ b/tests/unit/test_otlp.py
@@ -4,8 +4,6 @@
 """Feature: OTLP endpoints and rules transfer."""
 
 import json
-from contextlib import ExitStack
-from unittest.mock import patch
 
 import pytest
 from charmlibs.interfaces.otlp import OtlpEndpoint
@@ -314,82 +312,6 @@ def test_related_app_log_alerts_forwarded_over_otlp(ctx, forward_rules):
         assert RELATED_APP_LOG_ALERT in forwarded_log_alerts
     else:
         assert RELATED_APP_LOG_ALERT not in forwarded_log_alerts
-
-
-def test_reconcile_stages_otlp_rules_after_related_app_staging(ctx):
-    """Guard the temporal ordering contract that makes OTLP rule forwarding work.
-
-    `send_otlp` forwards whatever rule files are staged in the *_RULES_DEST_PATH directories, so it
-    MUST run:
-      * AFTER `cleanup` (which wipes the rule directories), and
-      * AFTER every integration that stages related-app alerts into those directories:
-        `scrape_metrics` (metrics-endpoint), `receive_loki_logs` (loki) and the cos-agent
-        `_add_alerts` calls in `charm._reconcile`.
-
-    This ordering is otherwise only enforced by a code comment, so a future reorder would silently
-    regress https://github.com/canonical/opentelemetry-collector-operator/issues/297. This test
-    spies on the reconcile call order to fail fast if that contract is broken.
-    """
-    # `charm.py` does `import integrations`, so spy on that same module object
-    import integrations
-
-    call_order: list[str] = []
-    spied = [
-        "cleanup",
-        "_add_alerts",  # cos-agent metrics/logs alerts staged from charm._reconcile
-        "receive_loki_logs",
-        "scrape_metrics",
-        "send_otlp",
-    ]
-    real = {name: getattr(integrations, name) for name in spied}
-
-    def make_spy(name):
-        def spy(*args, **kwargs):
-            call_order.append(name)
-            return real[name](*args, **kwargs)
-
-        return spy
-
-    # GIVEN a cos-agent principal staging alerts, a peers relation, and a send-otlp relation
-    provider_data = CosAgentProviderUnitData(
-        metrics_alert_rules=_postgresql_alert_groups(),
-        log_alert_rules={},
-        dashboards=[],
-        metrics_scrape_jobs=[],
-        log_slots=[],
-    )
-    cos_agent = SubordinateRelation(
-        "cos-agent",
-        remote_app_name="postgresql",
-        remote_unit_id=0,
-        remote_unit_data={CosAgentProviderUnitData.KEY: provider_data.json()},
-    )
-    state = State(
-        relations=[
-            cos_agent,
-            PeerRelation("peers"),
-            Relation("send-otlp", remote_app_data={"endpoints": "[]"}),
-        ],
-        leader=True,
-        model=MODEL,
-        config={"forward_alert_rules": True},
-    )
-
-    # WHEN any event executes the reconciler
-    with ExitStack() as stack:
-        for name in spied:
-            stack.enter_context(patch.object(integrations, name, make_spy(name)))
-        ctx.run(ctx.on.update_status(), state=state)
-
-    # THEN send_otlp runs after cleanup and after every related-app staging step
-    assert "send_otlp" in call_order
-    send_otlp_idx = call_order.index("send_otlp")
-    assert call_order.index("cleanup") < send_otlp_idx
-    for stager in ("_add_alerts", "receive_loki_logs", "scrape_metrics"):
-        assert stager in call_order, f"{stager} was not called"
-        # Use the LAST occurrence: every staging write must precede the forwarding read
-        last_idx = len(call_order) - 1 - call_order[::-1].index(stager)
-        assert last_idx < send_otlp_idx, f"send_otlp must run after {stager}"
 
 
 def test_forwarded_rules_have_topology(ctx):


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Fixes https://github.com/canonical/opentelemetry-collector-operator/issues/297

In tandem with: https://github.com/canonical/opentelemetry-collector-k8s-operator/pull/274

When opentelemetry-collector (machine) is related to a downstream collector over the `send-otlp`/`receive-otlp` interface, alert rules from **related applications** (e.g. `postgresql`, related over `cos-agent`/`metrics-endpoint`) were not present in the `send-otlp` relation data. Only the collector's own bundled rules were forwarded, so downstream Prometheus/Loki never received marker alerts such as `PostgresqlInvalidIndex`.

## Solution
<!-- A summary of the solution addressing the above issue -->


`send_otlp` published only the charm's **bundled** rules: it built the OTLP `RuleStore` from the source rule directories (`*_RULES_SRC_PATH`). The alert rules collected from related applications are staged into the **destination** rule directories (`*_RULES_DEST_PATH`) by other integrations, so they were never picked up. On top of that, `send_otlp` ran *before* those integrations had populated the destination directories.

This PR:

- **Reads the staged (DEST) rule directories** in `send_otlp` instead of the bundled (SRC) ones.
  The DEST directories already contain the bundled rules **plus** the alerts gathered from related applications:
  - `scrape_metrics` → `metrics-endpoint` alerts (`prometheus_alert_rules/`)
  - `receive_loki_logs` → `receive-loki-logs` alerts (`loki_alert_rules/`)
  - the `cos-agent` handling in `_reconcile` (leader-only) → cos-agent metrics/logs alerts
- **Reorders `_reconcile`** so `send_otlp` runs *after* the logs/metrics/cos-agent/remote-write
  integrations, guaranteeing the DEST directories are fully populated before the OTLP databag is published.
- **Hardens `cleanup()`** to resolve the rule directories against the absolute charm directory
  (now takes a `charm_root: Path`), matching the paths used by every integration that reads/writes them and making it independent of the process' current working directory.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

- The collector forwards alert rules by **reading rule files on disk**. Integrations copy bundled rules and write related-app rules into the `*_RULES_DEST_PATH` directories; the forwarding integrations (`send_remote_write`, `send_loki_logs`, and now `send_otlp`) read those same directories. The ordering between *staging* and *reading* is therefore load-bearing.
- Note on `forward_alert_rules`: the `metrics-endpoint` and `receive-loki-logs` staging is gated on this config, but the `cos-agent` alert staging in `_reconcile` is gated only on `is_leader()` (pre-existing behaviour, consistent with the cos-agent → `send-remote-write` path). As a result, cos-agent alerts are forwarded over OTLP regardless of `forward_alert_rules`. This is documented in the new tests and left unchanged here to keep the fix scoped to #297.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Unit tests:

```bash
tox -e unit
# or, just the OTLP feature:

tox -e unit -- -k test_otlp.py
```

New/updated tests in `tests/unit/test_otlp.py`:
- `test_related_app_alerts_forwarded_over_otlp` — related-app alert (via `metrics-endpoint`) is in
  the `send-otlp` databag, and its `juju_application` topology label is preserved.
- `test_related_app_alerts_forwarded_over_otlp_via_cos_agent` — same, exercising the real
  `cos-agent` subordinate path used by postgresql in production.
- `test_related_app_log_alerts_forwarded_over_otlp` — log (logql) alerts received over
  `receive-loki-logs` are forwarded.
- `test_reconcile_stages_otlp_rules_after_related_app_staging` — guards the reconcile call order
  (`send_otlp` runs after `cleanup` and after every related-app staging step).

To confirm the tests catch the regression, revert only `src/` and keep the test changes:

```bash
git checkout main -- src/charm.py src/integrations.py

tox -e unit -- -k test_otlp.py
# Expected: the new related-app forwarding tests FAIL
```

End-to-end (reproduces the issue scenario):

1. K8s model: deploy `opentelemetry-collector-k8s` + `prometheus`, offer the `receive-otlp`
2. Machine model: deploy `postgresql` + `opentelemetry-collector`, relate them over `cos-agent`. Consume the `receive-otlp` offer.
3. Verify the postgresql alert ruler reaches Prometheus:



## Upgrade Notes
<!-- To upgrade from an older revision, ... -->

No action required. After upgrading, alert rules from related applications (e.g. postgresql) will
start appearing in the `send-otlp` relation data on the next reconcile and propagate downstream. No
configuration or relation changes are needed.