### PR TITLE
feat: add queue to all exporters

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -170,6 +170,27 @@ class ConfigManager:
         }
 
     @property
+    def remote_write_queue_config(self) -> Dict[str, Any]:
+        """Return the queue and retry configuration for prometheusremotewrite exporters.
+
+        The prometheusremotewrite exporter does not support the standard ``sending_queue``
+        configuration block. Instead it exposes ``remote_write_queue`` for queue control
+        and inherits ``retry_on_failure`` from the exporterhelper.
+
+        See Also:
+            https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md
+        """
+        return {
+            "remote_write_queue": {
+                "enabled": True,
+                "queue_size": self._queue_size,
+            },
+            "retry_on_failure": {
+                "max_elapsed_time": f"{self._max_elapsed_time_min}m",
+            },
+        }
+
+    @property
     def prometheus_remotewrite_wal_config(self) -> Dict[str, Any]:
         """Return the default WAL configuration for Prometheus remote write.
 
@@ -298,6 +319,7 @@ class ConfigManager:
                         "insecure": endpoint.insecure,
                         "insecure_skip_verify": self._insecure_skip_verify,
                     },
+                    **self.sending_queue_config,
                 },
                 pipelines=["profiles"],
             )
@@ -382,6 +404,7 @@ class ConfigManager:
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
                     "add_metric_suffixes": False,
                     **self.prometheus_remotewrite_wal_config,
+                    **self.remote_write_queue_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],
             )
@@ -414,7 +437,11 @@ class ConfigManager:
             self.config.add_component(
                 Component.exporter,
                 f"{exporter_type}/rel-{rel_id}/{self._unit_name}",
-                {"endpoint": otlp_endpoint.endpoint, "tls": tls_config},
+                {
+                    "endpoint": otlp_endpoint.endpoint,
+                    "tls": tls_config,
+                    **self.sending_queue_config,
+                },
                 pipelines=[f"{_type}/{self._unit_name}" for _type in otlp_endpoint.telemetries],
             )
 
@@ -567,6 +594,7 @@ class ConfigManager:
                     "tls": {"insecure_skip_verify": self._insecure_skip_verify},
                     **exporter_auth_config,
                     **self.prometheus_remotewrite_wal_config,
+                    **self.remote_write_queue_config,
                 },
                 pipelines=[f"metrics/{self._unit_name}"],
             )

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -107,6 +107,10 @@ def test_add_remote_write():
         "tls": {
             "insecure_skip_verify": True,
         },
+        "retry_on_failure": {
+            "max_elapsed_time": "5m",
+        },
+        "remote_write_queue": {"enabled": True, "queue_size": 1000},
     }
     config_manager.add_remote_write(
         endpoints=[{"url": "http://192.168.1.244/cos-prometheus-0/api/v1/write"}],
@@ -291,14 +295,20 @@ def test_add_otlp_forwarding():
         f"otlp/rel-0/{unit_name}": {
             "endpoint": "1.2.3.4:grpc-port",
             "tls": {"insecure": False, "insecure_skip_verify": True},
+            "retry_on_failure": {"max_elapsed_time": "5m"},
+            "sending_queue": {"enabled": True, "queue_size": 1000, "storage": "file_storage"},
         },
         f"otlphttp/rel-1/{unit_name}": {
             "endpoint": "http://host-1:http-port",
             "tls": {"insecure": True, "insecure_skip_verify": True},
+            "retry_on_failure": {"max_elapsed_time": "5m"},
+            "sending_queue": {"enabled": True, "queue_size": 1000, "storage": "file_storage"},
         },
         f"otlp/rel-2/{unit_name}": {
             "endpoint": "host-2:grpc-port",
             "tls": {"insecure": True, "insecure_skip_verify": True},
+            "retry_on_failure": {"max_elapsed_time": "5m"},
+            "sending_queue": {"enabled": True, "queue_size": 1000, "storage": "file_storage"},
         },
     }
     # AND the exporters are added to the appropriate pipelines


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #115.

## Solution
<!-- A summary of the solution addressing the above issue -->
Adds a new proprty to ConfigManager called `remote_write_queue_config`. This is because the Remote Write Exporter uses a different config for configuring the queue. Read more [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md).

This PR also ensures that the sending queue option configured by the user applies to all exporters.
### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Deploy the 24.04 Ubuntu charm.
2. Pack this charm and deploy it.
3. Relate Ubuntu to your locally packed Otelcol.
4. Consume offers from a K8s model. You need offers for Prometheus' remote write endpoint, Loki's logging endpoint, and an Otelcol K8s' `receive-otlp` endpoint.
5. Configure `queue_size` in Otelcol. For example: `jc otelcol queue_size=10000`.
6. Look at Otelcol's config file: `cat /etc/otelcol/config.d/otelcol_0.yaml`.
7. The exporters should ALL have the appropriate queue size and retry logic configured.
```yaml
exporters:
  loki/send-loki-logs/0:
    default_labels_enabled:
      exporter: false
      job: true
    endpoint: http://loki-0.loki-endpoints.test.svc.cluster.local:8080/loki/api/v1/push
    retry_on_failure:
      max_elapsed_time: 5m
    sending_queue:
      enabled: true
      queue_size: 10000
      storage: file_storage
    tls:
      insecure_skip_verify: false
  otlp/rel-3/otelcol/0:
    endpoint: otelcol-0.otelcol-endpoints.test.svc.cluster.local:4317
    retry_on_failure:
      max_elapsed_time: 5m
    sending_queue:
      enabled: true
      queue_size: 10000
      storage: file_storage
    tls:
      insecure: true
      insecure_skip_verify: false
  prometheusremotewrite/send-remote-write/0:
    add_metric_suffixes: false
    endpoint: http://prom-0.prom-endpoints.test.svc.cluster.local:9090/api/v1/write
    remote_write_queue:
      enabled: true
      queue_size: 10000
    retry_on_failure:
      max_elapsed_time: 5m
    tls:
      insecure_skip_verify: false

```
## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
