### PR TITLE
fix: Dashboard cleanup for non-leader units

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -490,6 +490,9 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         config_manager.add_otlp_forwarding(otlp_endpoints)
 
         # Dashboards setup
+        ## Clean stale dashboard files on all units (cleanup() is leader-only but
+        ## _add_dashboards runs on all units, causing non-leaders to accumulate stale files)
+        shutil.rmtree(self.charm_dir.absolute().joinpath(*DASHBOARDS_DEST_PATH.split("/")), ignore_errors=True)
         ## COS Agent dashboards
         integrations._add_dashboards(
             dashboards=cos_agent.dashboards,


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This issue is blocking this PR:
- https://github.com/canonical/cos-proxy-operator/pull/241

When the `cos-proxy:dashboards` ↔ `rabbitmq-server:dashboards` relation is removed, dashboard files persist on disk in the otelcol subordinate. This causes stale dashboards to appear in Grafana.

Two separate bugs in otelcol (`src/charm.py`):

### 1. Leader-only cleanup

`cleanup()` at line 183 is only called for leader units, but `_add_dashboards()` at line 484 runs on ALL units. Non-leader units write dashboard files to disk but never clean the `grafana_dashboards/` directory, causing files to accumulate across `_reconcile()` calls.

### 2. Stale peer data timing

`_reconcile()` runs in `__init__` (before event dispatch), but `_on_relation_data_changed` runs during event dispatch. On the first event after a relation change, `_reconcile()` may read stale peer data from the cos-agent relation.

## Solution
<!-- A summary of the solution addressing the above issue -->
Added `shutil.rmtree` for `DASHBOARDS_DEST_PATH` on ALL units immediately before `_add_dashboards()` in `_reconcile()`. This ensures every unit starts with a clean slate before writing the current set of dashboards from peer data.

```python
# Dashboards setup
shutil.rmtree(self.charm_dir.absolute().joinpath(*DASHBOARDS_DEST_PATH.split("/")), ignore_errors=True)
## COS Agent dashboards
integrations._add_dashboards(
    dashboards=cos_agent.dashboards,
    dest_path=LocalPath(self.charm_dir.absolute().joinpath(DASHBOARDS_DEST_PATH)),
)
```

Flow After Fix:
1. **Leader**: `cleanup()` wipes all dirs (alerts + dashboards), then rebuilds everything
2. **All units**: wipe `grafana_dashboards/` dir, then `_add_dashboards(cos_agent.dashboards)` writes current dashboards
3. **Leader only**: `forward_dashboards()` adds built-in dashboards and creates the GrafanaDashboardProvider

Related Files:

- `src/charm.py:178-184` — `_reconcile()` with leader-only `cleanup()`
- `src/charm.py:482-491` — Dashboard setup with fix
- `src/integrations.py:69-79` — `cleanup()` function
- `src/integrations.py:412-444` — `_add_dashboards()` function
- `src/integrations.py:448-477` — `forward_dashboards()` (leader-only)
- `lib/charms/grafana_agent/v0/cos_agent.py:1391` — `COSAgentRequirer.dashboards` property
- `lib/charms/grafana_agent/v0/cos_agent.py:1222` — `_gather_peer_data()`


### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Cos-proxy side appears correct: `_dashboards_relation_broken` deletes files from `DASHBOARDS_DIR`, then `_on_refresh` (via `refresh_events`) reads both `COS_PROXY_DASHBOARDS_DIR` and empty `DASHBOARDS_DIR`, updates cos-agent unit databag without rabbitmq dashboards.

It is also important to note that we use the charms bundled dashboards dir for staging other dashboards. This could cause conflicts if we delete the charm's own dashboards.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy cos-proxy → otelcol (subordinate via cos-agent) → rabbitmq-server (subordinate via juju-info), with cos-proxy↔rabbitmq dashboards/rules/scrape relations.

Dashboard filenames follow pattern: `juju_{title}-{charm_name}-{rel_id}-{identity}.json`

- `juju_` is hardcoded by otelcol's `_add_dashboards()` (`integrations.py:442`)
- `[juju]` comes from rabbitmq-server charm's dashboard titles (Juju charm framework convention):
	- https://github.com/canonical/cos-proxy-operator/blob/64e6b819e3dd4ec401659c5403325485ccdf0be6/src/grafana_dashboards/rabbitmq.json.tmpl#L923


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
