### PR TITLE
fix: re-create snap lockfiles on every reconcile

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -188,6 +188,15 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         self._reconcile()
 
     def _reconcile(self):
+        # Re-assert this unit's snap registrations. These lockfiles are reference counts, read
+        # on removal to decide whether the last unit standing may uninstall a shared snap, so
+        # they belong to the desired state. Registering only on install/upgrade-charm left a
+        # lockfile that was deleted out of band missing until the next `juju refresh`.
+        # Refs https://github.com/canonical/opentelemetry-collector-operator/issues/208
+        manager = SingletonSnapManager(self.unit.name)
+        for snap_name in SnapMap.snaps():
+            manager.register(snap_name, SnapMap.get_revision(snap_name))
+
         insecure_skip_verify = cast(bool, self.config.get("tls_insecure_skip_verify"))
         topology = JujuTopology.from_charm(self)
         # NOTE: Only the leader aggregates alerts, to prevent duplication. COS Agent alerts

--- a/src/charm.py
+++ b/src/charm.py
@@ -193,9 +193,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         # they belong to the desired state. Registering only on install/upgrade-charm left a
         # lockfile that was deleted out of band missing until the next `juju refresh`.
         # Refs https://github.com/canonical/opentelemetry-collector-operator/issues/208
-        manager = SingletonSnapManager(self.unit.name)
-        for snap_name in SnapMap.snaps():
-            manager.register(snap_name, SnapMap.get_revision(snap_name))
+        self._register_snaps()
 
         insecure_skip_verify = cast(bool, self.config.get("tls_insecure_skip_verify"))
         topology = JujuTopology.from_charm(self)
@@ -620,13 +618,24 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
             return result
         return result.group(1)
 
-    def _install_snaps(self) -> None:
+    def _register_snaps(self) -> None:
+        """Reference-count this unit against every managed snap.
+
+        Registering is idempotent and cheap (one empty file per snap), which is what makes it
+        safe to call on every reconcile. Installing is neither, so it stays in `_install_snaps`.
+        """
         manager = SingletonSnapManager(self.unit.name)
+        for snap_name in SnapMap.snaps():
+            manager.register(snap_name, SnapMap.get_revision(snap_name))
+
+    def _install_snaps(self) -> None:
+        # Register before installing, so a snap that only partially installs, or whose service
+        # fails to start, is still reference counted for this unit.
+        self._register_snaps()
 
         for snap_name in SnapMap.snaps():
             snap_revision = SnapMap.get_revision(snap_name)
-            manager.register(snap_name, snap_revision)
-            revisions = manager.get_revisions(snap_name)
+            revisions = SingletonSnapManager.get_revisions(snap_name)
             if snap_revision >= (max(revisions) if revisions else 0):
                 # Install the snap
                 self.unit.status = MaintenanceStatus(f"Installing {snap_name} snap")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -110,8 +110,9 @@ def otelcol_version():
 
 @pytest.fixture(autouse=True)
 def mock_lock_dir(tmp_path):
-    with patch("singleton_snap.SingletonSnapManager.LOCK_DIR", tmp_path / "lock_dir"):
-        yield
+    lock_dir = tmp_path / "lock_dir"
+    with patch("singleton_snap.SingletonSnapManager.LOCK_DIR", lock_dir):
+        yield lock_dir
 
 
 @pytest.fixture(autouse=True)
@@ -180,13 +181,6 @@ def mock_snap_operations():
 def mock_add_alerts():
     """Suppress alert-rule injection during certificate-related tests."""
     with patch("integrations._add_alerts"):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def mock_singleton_snap_manager():
-    """Mock SingletonSnapManager methods."""
-    with patch("singleton_snap.SingletonSnapManager.get_revisions", return_value={1, 2}):
         yield
 
 

--- a/tests/unit/test_charm_lifecycle.py
+++ b/tests/unit/test_charm_lifecycle.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from ops.testing import State
 
 from charm import OpenTelemetryCollectorCharm
+from singleton_snap import SingletonSnapManager, SnapRegistrationFile
 
 
 def test_install_snaps_called_on_upgrade_charm(ctx):
@@ -38,3 +39,41 @@ def test_install_snaps_not_called_on_other_hooks(ctx):
     ):
         ctx.run(ctx.on.update_status(), State())
     mock_install.assert_not_called()
+
+
+def test_deleted_lockfile_is_recreated_on_any_hook(ctx, mock_lock_dir):
+    """Refs https://github.com/canonical/opentelemetry-collector-operator/issues/208.
+
+    Registering only on install/upgrade-charm meant a lockfile deleted out of band stayed
+    missing, which in turn wedged the unit in BlockedStatus until the next `juju refresh`.
+    """
+    # GIVEN no lockfiles exist, i.e. they were deleted out of band
+    # WHEN an ordinary hook executes the reconciler
+    state_out = ctx.run(ctx.on.update_status(), State())
+    # THEN this unit is registered again for every managed snap
+    assert SingletonSnapManager.get_units("opentelemetry-collector") == {"otelcol_0"}
+    assert SingletonSnapManager.get_units("node-exporter") == {"otelcol_0"}
+    # AND the unit is not blocked on a bogus revision mismatch
+    assert state_out.unit_status.name == "active"
+
+
+def test_registration_does_not_hide_a_co_located_revision_mismatch(ctx, mock_lock_dir):
+    """Re-registering must not neuter the co-tenancy check.
+
+    The snap is shared by every collector unit on a machine, so a unit pinning an older
+    revision than a co-located one must still block.
+    """
+    # GIVEN a co-located unit registered for a newer node-exporter revision than this unit
+    # pins (mocked to 2)
+    mock_lock_dir.mkdir(parents=True, exist_ok=True)
+    other_unit = SnapRegistrationFile(
+        unit_name="otelcol/1", snap_name="node-exporter", snap_revision=99
+    )
+    (mock_lock_dir / other_unit.filename).touch()
+    # WHEN the reconciler runs
+    state_out = ctx.run(ctx.on.update_status(), State())
+    # THEN this unit still blocks on the mismatch
+    assert state_out.unit_status.name == "blocked"
+    assert "Mismatching snap revisions for node-exporter" in state_out.unit_status.message
+    # AND the co-located unit's registration was left untouched
+    assert SingletonSnapManager.get_units("node-exporter") == {"otelcol_0", "otelcol_1"}


### PR DESCRIPTION
## Issue

Closes #208.

`SingletonSnapManager.register()` was only called from `_install_snaps()`, which runs on the `install` and `upgrade-charm` hooks. A lockfile deleted was therefore never re-created.


## Solution

Register at the top of `_reconcile()`, so the lockfiles are treated as desired state.

`register()` prunes only lockfiles whose `unit_name` matches the calling unit, so re-registering does not touch co-located units' entries.

Also drops the autouse `mock_singleton_snap_manager` fixture, which stubbed `get_revisions()` and masked this area from the unit tests. 

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened.


## Context

`opentelemetry-collector` and `node-exporter` are machine-wide singleton snaps: one installed
revision per machine, shared by every co-located collector unit. `/opt/singleton_snaps` holds one lockfile per (snap, unit), `LCK..<snap>--rev<N>__<unit>`, which reference-counts units so the last one standing knows it may uninstall the snap on removal.


## Testing Instructions

Unit tests — two added to `tests/unit/test_charm_lifecycle.py`, both verified to fail without the fix:

```
tox run -e unit
```

Manual, following the reproduction steps in #208:

```bash
juju deploy ubuntu
juju deploy opentelemetry-collector otelcol
juju integrate otelcol:juju-info ubuntu:juju-info
```

> With only `juju-info` and no outgoing telemetry relation, `otelcol` is expected to sit in
> `blocked` on missing mandatory relations. That is unrelated to this fix — what matters below is the status *message*, not the status itself.

```bash
# delete a lockfile out of band
juju ssh ubuntu/0 'sudo rm /opt/singleton_snaps/LCK..node-exporter--rev*'

# trigger a hook (the reconcile action is the most reliable trigger)
juju run otelcol/0 reconcile
```

Expected: the lockfile reappears, and the unit does **not** report `Mismatching snap revisions for node-exporter`. Before this change it did, and stayed there through any number of hooks.

To confirm co-tenancy detection is still live, plant a lockfile for a fictitious unit pinning a
newer revision — the unit must then report the mismatch:

```bash
juju ssh ubuntu/0 'sudo touch /opt/singleton_snaps/LCK..node-exporter--rev9999__otelcol_99'
juju run otelcol/0 reconcile
# clean up, or the unit stays blocked
juju ssh ubuntu/0 'sudo rm /opt/singleton_snaps/LCK..node-exporter--rev9999__otelcol_99'
```
