### PR TITLE
feat: blocked on invalid alert rules over prometheus_scrape

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,6 @@ from charms.grafana_agent.v0.cos_agent import COSAgentRequirer
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from charms.operator_libs_linux.v1.systemd import service_start
 from charms.operator_libs_linux.v2 import snap  # type: ignore
-from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from cosl import JujuTopology, MandatoryRelationPairs
 from ops import BlockedStatus, CharmBase, RelationChangedEvent
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
@@ -606,7 +605,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         # Invalid alert rules
         if self._has_invalid_prometheus_alerts():
             self.unit.status = BlockedStatus("Invalid Prometheus alerts. See debug-log")
-        
+
         # Invalid scrape jobs
         if self._has_invalid_scrape_job():
             self.unit.status = BlockedStatus("Invalid scrape jobs. See debug-log")
@@ -923,7 +922,7 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
     def _has_invalid_prometheus_alerts(self) -> bool:
         """Check if any metrics-endpoint relation reported invalid alert rules."""
         return self.metrics_consumer.has_invalid_alert_rules()
-    
+
     def _has_invalid_scrape_job(self) -> bool:
         """Check if any metrics-endpoint relation reported invalid scrape jobs."""
         return self.metrics_consumer.has_invalid_scrape_jobs()

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Mapping, Optional, cast
 import ops
 from charmlibs.pathops import LocalPath
 from charms.grafana_agent.v0.cos_agent import COSAgentRequirer
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from charms.operator_libs_linux.v1.systemd import service_start
 from charms.operator_libs_linux.v2 import snap  # type: ignore
 from cosl import JujuTopology, MandatoryRelationPairs
@@ -168,6 +169,8 @@ def _get_missing_mandatory_relations(charm: CharmBase) -> Optional[str]:
 
 class OpenTelemetryCollectorCharm(ops.CharmBase):
     """Charm the service."""
+
+    metrics_consumer: MetricsEndpointConsumer
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
@@ -599,6 +602,10 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
         if missing_relations := _get_missing_mandatory_relations(self):
             self.unit.status = BlockedStatus(missing_relations)
 
+        # Invalid alert rules
+        if self._has_invalid_prometheus_alerts():
+            self.unit.status = BlockedStatus("Invalid Prometheus alerts. See debug-log")
+
         # Workload version
         self.unit.set_workload_version(self._otelcol_version or "")
 
@@ -907,6 +914,10 @@ class OpenTelemetryCollectorCharm(ops.CharmBase):
     @property
     def _has_server_cert_relation(self) -> bool:
         return any(self.model.relations.get("receive-server-cert", []))
+
+    def _has_invalid_prometheus_alerts(self) -> bool:
+        """Check if any metrics-endpoint relation reported invalid alert rules."""
+        return self.metrics_consumer.has_invalid_alert_rules()
 
     @property
     def _node_exporter_info_metric_file_path(self) -> LocalPath:

--- a/tests/unit/test_alert_rule_filtering.py
+++ b/tests/unit/test_alert_rule_filtering.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for blocking on invalid alert rules from prometheus_scrape."""
+
+import json
+
+from ops.testing import Relation, State
+from scenario import BlockedStatus
+
+
+def _metrics_endpoint_relation(*, event_data: dict) -> Relation:
+    """Build a metrics-endpoint Relation with the given app-level event data."""
+    return Relation(
+        endpoint="metrics-endpoint",
+        local_app_data={"event": json.dumps(event_data)},
+    )
+
+
+def test_valid_alert_rules_active(ctx):
+    """Scenario: valid alert rules over metrics-endpoint → ActiveStatus."""
+    # GIVEN a metrics-endpoint relation with no errors in app data
+    relation = _metrics_endpoint_relation(event_data={})
+    state = State(leader=True, relations=[relation])
+
+    # WHEN the charm reconciles
+    state_out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN the charm is not blocked
+    assert not isinstance(state_out.unit_status, BlockedStatus)
+
+
+def test_invalid_alert_rules_blocked(ctx):
+    """Scenario: invalid alert rules over metrics-endpoint → BlockedStatus."""
+    # GIVEN a metrics-endpoint relation with alert rule validation errors in app data
+    error_msg = "error validating rule: parse error: unexpected token"
+    relation = _metrics_endpoint_relation(event_data={"errors": error_msg})
+    state = State(leader=True, relations=[relation])
+
+    # WHEN the charm reconciles
+    state_out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN the charm enters BlockedStatus
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    # AND the status message points to the debug-log
+    assert state_out.unit_status.message == "Invalid Prometheus alerts. See debug-log"
+
+
+def test_non_leader_ignores_invalid_alert_rules(ctx):
+    """Scenario: non-leader units do not block on invalid alert rules."""
+    # GIVEN a metrics-endpoint relation with errors, but this unit is NOT the leader
+    error_msg = "error validating rule: parse error: unexpected token"
+    relation = _metrics_endpoint_relation(event_data={"errors": error_msg})
+    state = State(leader=False, relations=[relation])
+
+    # WHEN the charm reconciles
+    state_out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN the charm is not blocked (non-leaders skip alert rule error detection)
+    assert not isinstance(state_out.unit_status, BlockedStatus)
+
+
+def test_alert_rule_errors_cleared_after_fix(ctx):
+    """Scenario: after errors are cleared from relation data, charm recovers to ActiveStatus."""
+    # GIVEN a metrics-endpoint relation with no errors (errors were previously present and fixed)
+    relation = _metrics_endpoint_relation(event_data={})
+    state = State(leader=True, relations=[relation])
+
+    # WHEN the charm reconciles
+    state_out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN the charm is not blocked
+    assert not isinstance(state_out.unit_status, BlockedStatus)
+
+
+def test_multiple_relations_one_invalid_blocks(ctx):
+    """Scenario: one invalid relation among multiple blocks the charm."""
+    # GIVEN one valid and one invalid metrics-endpoint relation
+    valid_relation = _metrics_endpoint_relation(event_data={})
+    invalid_relation = _metrics_endpoint_relation(
+        event_data={"errors": "parse error: invalid PromQL expression"}
+    )
+    state = State(leader=True, relations=[valid_relation, invalid_relation])
+
+    # WHEN the charm reconciles
+    state_out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN the charm enters BlockedStatus
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert state_out.unit_status.message == "Invalid Prometheus alerts. See debug-log"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Similar to: https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/340
Fixes #381.

## Solution
<!-- A summary of the solution addressing the above issue -->
Block Otelcol if there are invalid alert rules coming over `prometheus_scrape`.
### Checklist
- [ ] I have added or updated relevant documentation.
- [ ] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [ ] Merge target is the correct branch, and relevant tandem backport PRs opened. 


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision, ... -->
